### PR TITLE
This isn't well documented in the Google APIs, but you can request the l...

### DIFF
--- a/application/helpers/AssetFunctions.php
+++ b/application/helpers/AssetFunctions.php
@@ -139,8 +139,8 @@ function display_js($includeDefaults = true)
             $headScript->prependFile(src('jquery-ui', $dir, 'js'))
                        ->prependFile(src('jquery', $dir, 'js'));
         } else {
-            $headScript->prependFile('https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.16/jquery-ui.min.js')
-                       ->prependFile('https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js');
+            $headScript->prependFile('https://ajax.googleapis.com/ajax/libs/jqueryui/1.8/jquery-ui.min.js')
+                       ->prependFile('https://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js');
         }
     }
 


### PR DESCRIPTION
...atest version of a library with varying degrees of specificity.

https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js // exceptionally specific
https://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js // latest 1.7 version
https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js // latest 1 version

Ran in to a bug in 1.4.2 that called jquery 1.6.1 which had a bug that got fixed in 1.6.3. 

Calling the libraries from the CDN in this way will ensure that the latest bug fixes are always included with a stable API.
