### PR TITLE
Adds filters for all media callbacks in Omeka_View_Helper_Media.

### DIFF
--- a/application/helpers/Media.php
+++ b/application/helpers/Media.php
@@ -760,7 +760,10 @@ class Omeka_View_Helper_Media
         $wrapper = !empty($wrapperAttributes) ? '<div ' . _tag_attributes($wrapperAttributes) . '>' : ''; 
         $html = !empty($wrapper) ? $wrapper . $html . "</div>" : $html;
         
-        return $html;
+        $filterName = 'file_' . Inflector::underscore($callback) . '_display';
+        $filterName = str_replace('display_display', 'display', $filterName); // Avoid creating a 'file_default_display_display' filter name. 
+
+        return apply_filters($filterName, $html, $file, $options, $wrapperAttributes);
     }
     
     private function _getFileExtension($file)


### PR DESCRIPTION
Uses 'file_[callback]_display' for the filter name. (E.g. file_image_display.)

Available parameters in the filter include:
- $file
- $options (a combination of props passed to the Media bootstrap and default
  options for the given callback.
- $wrapperAttributes

Employs a string replace for 'display_display' to avoid a redundant filter
name for the defaultDisplay callback.

Refs #145
