### PR TITLE
Set the $path var. Not initialized in this function, so you get a warning

### DIFF
--- a/application/views/helpers/Media.php
+++ b/application/views/helpers/Media.php
@@ -829,6 +829,7 @@ class Omeka_View_Helper_Media
         }
         
         if ($width || $height) {
+            $path = html_escape($file->getWebPath('archive'));
             list($oWidth, $oHeight) = getimagesize( $path );
             
             if ($oWidth > $width && !$height) {


### PR DESCRIPTION
You get the warning when you call that for example :

echo display_files_for_item(Array("imageSize" => "fullsize", "imgAttributes" => Array("width" => "650px")));

Checked on 1.5 version, didn't go further.
