### PR TITLE
Checks for 'public' and 'featured' in request on advanced search form.

### DIFF
--- a/application/views/scripts/items/advanced-search.php
+++ b/application/views/scripts/items/advanced-search.php
@@ -148,7 +148,8 @@ $formAttributes['method'] = 'GET';
             <div class="inputs">
                 <?php echo select(array('name' => 'public', 'id' => 'public'),
                     array('1' => __('Only Public Items'),
-                          '0' => __('Only Non-Public Items'))); ?>
+                          '0' => __('Only Non-Public Items'))
+                    @$_REQUEST['public']); ?>
             </div>
         </div>
         <?php endif; ?>
@@ -158,7 +159,8 @@ $formAttributes['method'] = 'GET';
             <div class="inputs">
                 <?php echo select(array('name' => 'featured', 'id' => 'featured'),
                     array('1' => __('Only Featured Items'),
-                          '0' => __('Only Non-Featured Items'))); ?>
+                          '0' => __('Only Non-Featured Items'))
+                    @$_REQUEST['featured']); ?>
             </div>
         </div>
 


### PR DESCRIPTION
The public and featured fields on the advanced search form do not display a value if there is one on the request.
