### PR TITLE
Simplify and improve file functions used to set derivative filenames.

### DIFF
--- a/application/libraries/Omeka/File/Derivative/Image.php
+++ b/application/libraries/Omeka/File/Derivative/Image.php
@@ -231,11 +231,9 @@ class Omeka_File_Derivative_Image
      */
     protected static function _getFileName($archiveFilename)
     {
-        $filename = basename($archiveFilename);
-        $newName = explode('.', $filename);
-        //ensures that all generated files are jpeg
-        $newName[1] = self::DERIVATIVE_EXT;
-        return implode('.', $newName);
+        // Ensures that all generated files are jpeg.
+        $base = pathinfo($archiveFilename, PATHINFO_FILENAME);
+        return $base . '.' . self::DERIVATIVE_EXT;
     }
 
     /**

--- a/application/models/File.php
+++ b/application/models/File.php
@@ -131,9 +131,8 @@ class File extends Omeka_Record
     
     public function getDerivativeFilename()
     {
-        list($base, $ext) = explode('.', $this->archive_filename);
-        $fn = $base . '.' . Omeka_File_Derivative_Image::DERIVATIVE_EXT;
-        return $fn;        
+        $base = substr($this->archive_filename, 0, strrpos($this->archive_filename, '.'));
+        return $base . '.' . Omeka_File_Derivative_Image::DERIVATIVE_EXT;
     }
     
     public function hasThumbnail()


### PR DESCRIPTION
Hi,

As I explain on [Omeka forum](http://omeka.org/forums/topic/urls-and-files-with-true-names#post-9224) (first part of the post), I'm currently creating a digital library for 200000 scanned images of old books, in seven collections. Everything works fine on a small set, thanks to Omeka!

But Omeka saves each image in one folder, "archives/files", and our server cannot support a large number of files in one folder. So we need to create subfolders. In fact, we would like that Omeka saves images with a path like that: archive / files / collection / dc:identifier / file_0001.jpg. 

So I create a plugin, [ArchiveRepertory](https://github.com/Daniel-KM/ArchiveRepertory), to do that. It works fine on Omeka 1.5.3! 

But to work, eight lines should be modified in Omeka core. That's the reason of this patch. 

This patch changes nothing to the normal behavior of Omeka. In fact, it improves two functions to manage rare files with two or more dots (".") in their name (while currently, since some releases, Omeka uses a hashed name with only one dot).

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
