### PR TITLE
Add TravisCI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,5 @@ before_script:
 
 script: cd application/tests && phpunit --coverage-text
 
-notifications:
-  irc: "irc.freenode.org#omeka"
+#notifications:
+  #irc: "irc.freenode.org#omeka"


### PR DESCRIPTION
TravisCI is a hosted continuous integration service integrated with github.
TravisCI is automated to run tests when a committer pushes to Github, and
allows feedback if someone breaks the build. This also allows the testing of
pull requests from github, so patches don't also break the build.

There's also a nice banner image you can add to the README that displays the
current build status for the project.

See http://travis-ci.org/#!/waynegraham/Omeka for result output...
