### PR TITLE
Add admin bar to public site for logged-in users.

### DIFF
--- a/application/views/scripts/common/admin-bar.php
+++ b/application/views/scripts/common/admin-bar.php
@@ -1,0 +1,13 @@
+<?php if ($user = current_user()): ?>
+<ul id="admin-bar">
+<?php
+    $links = array(
+      __('Welcome, %s', $user->name) => uri('users/edit/'.$user->id),
+      __('Omeka Admin') => admin_uri(),
+      __('Log Out') => uri('users/logout')
+    );
+
+    echo nav(apply_filters('admin_bar_nav', $links));
+?>
+</ul>
+<?php endif; ?>

--- a/application/views/scripts/css/admin-bar.css
+++ b/application/views/scripts/css/admin-bar.css
@@ -1,0 +1,45 @@
+#admin-bar {
+    position:absolute;
+    width: 100%;
+    box-sizing:border-box;
+    top:0;
+    left:0;
+    margin:0;
+    padding:0;
+    background: rgba(0,0,0,0.75);
+    line-height: 30px;
+    color: #fff;
+    text-align:right;
+    font-family:Arvo, serif !important;
+    font-size: 12px;
+}
+
+#admin-bar li {
+    display:inline-block;
+    margin:0;
+    padding:0;
+    font-family:Arvo, serif !important; /* Ensure unform font family across themes.*/
+    font-size:1em; /* Ensure uniform font size across themes. */
+}
+
+#admin-bar a {
+    display:block;
+    text-decoration:none;
+    padding: 0 1em 0 0;
+    font-family:Arvo, serif !important; /* Ensure unform font family across themes.*/
+    font-size:1em; /* Ensure uniform font size across themes. */
+}
+
+#admin-bar li a:link,
+#admin-bar li a:visited {
+    color: #ccc !important;
+}
+
+#admin-bar li a:hover,
+#admin-bar li a:active {
+    color: #fff !important;
+}
+
+body.admin-bar {
+    padding-top: 30px; /* Matches line-height for #admin-bar. */
+}

--- a/application/views/scripts/custom.php
+++ b/application/views/scripts/custom.php
@@ -15,3 +15,10 @@ add_filter('html_escape', 'nl2br', 2);
 add_filter(array('Display', 'Item', 'Dublin Core', 'Title'), 'show_untitled_items');
 
 add_plugin_hook('public_theme_header', 'custom_header_background');
+
+// If there is a current user, add admin_bar.
+if (current_user()) {
+    add_plugin_hook('public_theme_header', 'admin_bar_css');
+    add_plugin_hook('public_theme_body', 'admin_bar');
+    add_filter('body_tag_attributes', 'admin_bar_class');
+}

--- a/application/views/scripts/functions.php
+++ b/application/views/scripts/functions.php
@@ -86,3 +86,26 @@ function custom_header_background()
         echo $html;
     }
 }
+
+/**
+ * Partial for the admin bar.
+ */
+function admin_bar() {
+    common('admin-bar');
+}
+
+/**
+ * Styles for admin bar.
+ */
+function admin_bar_css() {
+    __v()->headLink()->appendStylesheet('http://fonts.googleapis.com/css?family=Arvo:400', 'screen');
+    queue_css('admin-bar', 'screen');
+}
+
+/**
+ * Adds 'admin-bar' to the class attribute for the body tag.
+ */
+function admin_bar_class($attributes) {
+    $attributes['class'] = trim('admin-bar '.$attributes['class']);
+    return $attributes;
+}


### PR DESCRIPTION
Adds a 'common/admin-bar.php' partial for admin bar markup. Includes a
'admin_bar_nav' filter for modifying the contents of the admin bar navigation.

Admin bar is styled with 'css/admin-bar.css'. It is absolutely
positioned at the top of the the theme. The Google Fonts CSS for the
Arvo font is also included, so the admin bar font matches the admin panel. A
class of 'admin-bar' is added to the body for styling purposes, particularly
to push the rest of the theme down to account for the height of the admin bar.

The admin-bar partial, CSS, and body class are all added only if there is a
current user logged in. The admin-bar is added through the 'public_theme_body'
hook. The styles are added through the CSS queue.

Refs #37.
