### PR TITLE
Fixes exception when there is no random featured collection.

### DIFF
--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -1182,10 +1182,9 @@ function web_path_to($file)
  */
 function random_featured_collection()
 {
-    $featuredCollection = get_random_featured_collection();
-    $featuredCollectionTitle = strip_formatting(metadata($featuredCollection, array('Dublin Core', 'Title')));
     $html = '<h2>' . __('Featured Collection') . '</h2>';
-    if ($featuredCollection) {
+    if ($featuredCollection = get_random_featured_collection()) {
+        $featuredCollectionTitle = strip_formatting(metadata($featuredCollection, array('Dublin Core', 'Title')));
         $html .= '<h3>' . link_to_collection($featuredCollectionTitle, array(), 'show', $featuredCollection) . '</h3>';
         if ($collectionDescription = metadata($featuredCollection, array('Dublin Core', 'Description'), array('snippet'=>150))) {
             $html .= '<p class="collection-description">' . $collectionDescription . '</p>';

--- a/application/tests/suite/Helpers/CollectionFunctions/RandomFeaturedCollectionTest.php
+++ b/application/tests/suite/Helpers/CollectionFunctions/RandomFeaturedCollectionTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Roy Rosenzweig Center for History and New Media, 2011
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt
+ * @package Omeka
+ */
+
+/**
+ * Tests random_featured_collection()
+ *
+ * @package Omeka
+ */
+class Omeka_Helper_RandomFeaturedCollectionTest extends Omeka_Test_AppTestCase
+{
+
+    /**
+     * Checks that the correct message is displayed if there are no featured 
+     * collections to display.
+     */
+    public function testNoRandomFeaturedCollection()
+    {
+        $html = random_featured_collection();
+        $this->assertContains('No featured collections are available.', $html);
+    }
+
+}


### PR DESCRIPTION
Updated `random_featured_collection` to not throw an exception if there is no
random featured collection to display. The function instead displays a
messsage that there are no featured collections available. Includes a test to
check whether this message is displayed.
