### PR TITLE
Uses all_element_texts on collections/show view.

### DIFF
--- a/application/views/scripts/collections/show.php
+++ b/application/views/scripts/collections/show.php
@@ -10,21 +10,7 @@ if ($collectionTitle == '') {
 <div id="primary">
     <h1><?php echo $collectionTitle; ?></h1>
 
-    <div id="description" class="element">
-        <h2><?php echo __('Description'); ?></h2>
-        <div class="element-text"><?php echo text_to_paragraphs(metadata('collection', array('Dublin Core', 'Description'))); ?></div>
-    </div><!-- end description -->
-
-    <?php if ($collection->hasContributor()): ?>
-    <div id="contributors" class="element">
-        <h2><?php echo __('Contributor(s)'); ?></h2>
-        <div class="element-text">
-            <ul>
-                <li><?php echo metadata('collection', array('Dublin Core', 'Contributor'), array('all'=>true, 'delimiter'=>'</li><li>')); ?></li>
-            </ul>
-        </div>
-    </div><!-- end contributors -->
-    <?php endif; ?>
+    <?php echo all_element_texts('collection'); ?>
 
     <p class="view-items-link"><?php echo link_to_items_browse(__('View the items in %s', $collectionTitle), array('collection' => metadata('collection', 'id'))); ?></p>
 


### PR DESCRIPTION
Displays all element texts for collections instead of displaying only
Description and Collectors.

Fixes #358.
