### PR TITLE
Adds options param to javascript queue functions.

### DIFF
--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -938,16 +938,18 @@ function format_date($date, $format = Zend_Date::DATE_MEDIUM)
  * member will be treated like a file.
  * @param string $dir Directory to search for the file. Keeping the default is 
  * recommended.
+ * @param array $options An array of options.
  */
-function queue_js_file($file, $dir = 'javascripts')
+function queue_js_file($file, $dir = 'javascripts', $options = array())
 {
     if (is_array($file)) {
         foreach ($file as $singleFile) {
-            queue_js_file($singleFile, $dir);
+            queue_js_file($singleFile, $dir, $options);
         }
         return;
     }
-    get_view()->headScript()->appendFile(src($file, $dir, 'js'));
+
+    get_view()->headScript()->appendFile(src($file, $dir, 'js'), null, $options);
 }
 
 /**
@@ -959,10 +961,11 @@ function queue_js_file($file, $dir = 'javascripts')
  * @package Omeka\Function\View\Head
  * @see head_js()
  * @param string $string JavaScript string to include.
+ * @param array $options An array of options.
  */
-function queue_js_string($string)
+function queue_js_string($string, $options = array())
 {
-    get_view()->headScript()->appendScript($string);
+    get_view()->headScript()->appendScript($string, null, $options);
 }
 
 /**

--- a/application/tests/suite/Helpers/AssetFunctions/DisplayJsTest.php
+++ b/application/tests/suite/Helpers/AssetFunctions/DisplayJsTest.php
@@ -113,4 +113,26 @@ class Omeka_Helper_DisplayJsTest extends PHPUnit_Framework_TestCase
             "Script tag for inline script not found.");
         $this->assertContains($script, $output);
     }
+
+    public function testQueueJsConditional()
+    {
+        queue_js_file('search', 'javascripts', array('conditional' => 'lt IE 9'));
+
+        $output = $this->_getJsOutput(false);
+
+        $this->assertContains('<!--[if lt IE 9]>', $output);
+
+    }
+
+    public function testQueueJsStringConditional()
+    {
+        $script = 'Inline JS script.';
+        queue_js_string($script, array('conditional' => 'lt IE 9'));
+
+        $output = $this->_getJsOutput(false);
+
+        $this->assertContains('<!--[if lt IE 9]>', $output);
+        $this->assertContains($script, $output);
+    }
+
 }


### PR DESCRIPTION
Adds an option parameter to `queue_js_file` and `queue_js_string` to allow
for, among other things, wrapping the outputs of those with conditional
comments similar to the CSS queue functions.

Other options can be passed as well, per the Zend Framework documentation for
[headScript](http://framework.zend.com/manual/1.12/en/zend.view.helpers.html#zend.view.helpers.initial.headscript).

Updates the test that shall not be named to check for these conditional
comments.
