### PR TITLE
Changing UsersController::_getUserForm to protected

### DIFF
--- a/application/controllers/UsersController.php
+++ b/application/controllers/UsersController.php
@@ -415,7 +415,7 @@ class UsersController extends Omeka_Controller_AbstractActionController
         $this->_helper->redirector->gotoUrl('');
     }
     
-    private function _getUserForm(User $user)
+    protected function _getUserForm(User $user)
     {
         $hasActiveElement = $user->exists()
             && $this->_helper->acl->isAllowed('change-status', $user);


### PR DESCRIPTION
Changing UsersController::_getUserForm from private to protected. Fixes #429.

This is a useful change for plugins to be able to get better leverage the current admin user forms.
