### PR TITLE
Localize default item citation format.

### DIFF
--- a/application/languages/Omeka.pot
+++ b/application/languages/Omeka.pot
@@ -2793,6 +2793,10 @@ msgid ""
 "Files cannot be attached to an item that is not persistent in the database!"
 msgstr ""
 
+#: application/models/Item.php:415
+msgid "accessed"
+msgstr ""
+
 #: application/models/Item.php:431
 msgid "Cannot add an existing file to an item!"
 msgstr ""

--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -408,9 +408,11 @@ class Item extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
             $citation .= "<em>$siteTitle</em>, ";
         }
         
-        $accessed = date('F j, Y');
+        $locale = Zend_Registry::get('Zend_Locale');
+        setlocale(LC_TIME, $locale);
+        $accessed = strftime('%x');
         $url = html_escape(record_url($this, null, true));
-        $citation .= "accessed $accessed, $url.";
+        $citation .= __("accessed") ." ". $accessed .", ". $url . ".";
         
         return apply_filters('item_citation', $citation, array('item' => $this));
     }


### PR DESCRIPTION
This modification formats citation date according to current Zend locale and wraps 'accessed' text with localization function. 
