### PR TITLE
Using array_key_exists when loading plugin paths

### DIFF
--- a/application/libraries/Omeka/Controller/Plugin/ViewScripts.php
+++ b/application/libraries/Omeka/Controller/Plugin/ViewScripts.php
@@ -152,7 +152,7 @@ class Omeka_Controller_Plugin_ViewScripts extends Zend_Controller_Plugin_Abstrac
             
             // add the scripts from the first module
             $pluginScriptDirs = $this->_pluginMvc->getModuleViewScriptDirs($pluginModuleName);
-            if ($pluginScriptDirs[$themeType]) {
+            if (array_key_exists($themeType, $pluginScriptDirs)) {
                 foreach ($pluginScriptDirs[$themeType] as $scriptPath) {
                     $this->_addPathToView($scriptPath);
                 }


### PR DESCRIPTION
I was running into a php Notice when loading a plugin that didn't have a `views/public` folder. This pull switches over to `array_key_exists` when looking for plugin paths.

Notice: Undefined index: public in /var/www/html/digital_gallery/application/libraries/Omeka/Controller/Plugin/ViewScripts.php on line 155
