### PR TITLE
Making sure the plugin script directories variable is an array.

### DIFF
--- a/application/libraries/Omeka/Controller/Plugin/ViewScripts.php
+++ b/application/libraries/Omeka/Controller/Plugin/ViewScripts.php
@@ -152,7 +152,7 @@ class Omeka_Controller_Plugin_ViewScripts extends Zend_Controller_Plugin_Abstrac
             
             // add the scripts from the first module
             $pluginScriptDirs = $this->_pluginMvc->getModuleViewScriptDirs($pluginModuleName);
-            if (is_array($pluginScriptDirs) && array_key_exists($themeType, $pluginScriptDirs)) {
+            if (isset($pluginScriptDirs[$themeType])) {
                 foreach ($pluginScriptDirs[$themeType] as $scriptPath) {
                     $this->_addPathToView($scriptPath);
                 }


### PR DESCRIPTION
$pluginScriptDirs was giving me null sometimes, so I updated the check to make sure we have an array. Below was the error I was getting.

Warning: array_key_exists() expects parameter 2 to be array, null given in /var/www/html/digital_gallery/application/libraries/Omeka/Controller/Plugin/ViewScripts.php on line 155
