### PR TITLE
Remove hardcoded http protocol to allow for automatic SSL compatibility.

### DIFF
--- a/admin/themes/default/common/login-header.php
+++ b/admin/themes/default/common/login-header.php
@@ -10,7 +10,7 @@
     <?php queue_css_file('layout'); ?>
     <?php queue_css_file('skeleton'); ?>
     <?php echo head_css(); ?>
-    <link href='http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
     <!-- JavaScripts -->
     <?php

--- a/application/views/scripts/functions.php
+++ b/application/views/scripts/functions.php
@@ -27,7 +27,7 @@ function admin_bar() {
  * Styles for admin bar.
  */
 function admin_bar_css() {
-    queue_css_url('http://fonts.googleapis.com/css?family=Arvo:400', 'screen');
+    queue_css_url('//fonts.googleapis.com/css?family=Arvo:400', 'screen');
     queue_css_file('admin-bar', 'screen');
 }
 


### PR DESCRIPTION
In order to get our SSL'ed Omeka instance working (mbda.berry.edu) without several of the browsers throwing the user-terrifying 'some items are insecure' kinds of messages, I had to adjust the CDN calls to drop the hardcoded http:.

I would assume others who would want an SSLed site would have to do the same, and thought you might want to change it to something along these lines so it would be automatic. Thanks!
