### PR TITLE
Use 'type' key for item type field in advanced search.

### DIFF
--- a/admin/themes/default/items/search-form.php
+++ b/admin/themes/default/items/search-form.php
@@ -117,7 +117,7 @@ $formAttributes['method'] = 'GET';
             <?php
                 echo $this->formSelect(
                     'type',
-                    @$_REQUEST['item-type-search'],
+                    @$_REQUEST['type'],
                     array('id' => 'item-type-search'),
                     get_table_options('ItemType')
                 );

--- a/application/views/scripts/items/search-form.php
+++ b/application/views/scripts/items/search-form.php
@@ -108,7 +108,7 @@ $formAttributes['method'] = 'GET';
         <?php
             echo $this->formSelect(
                 'type',
-                @$_REQUEST['item-type-search'],
+                @$_REQUEST['type'],
                 array('id' => 'item-type-search'),
                 get_table_options('ItemType')
             );


### PR DESCRIPTION
Changes the key on $_REQUEST to 'type' instead of 'item-type-search', so that
the item type field is corrected selected if that parameter is set on the
advanced search page.
