### PR TITLE
Normalized function used to get derivative filename.

### DIFF
--- a/application/models/File.php
+++ b/application/models/File.php
@@ -266,14 +266,8 @@ class File extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
      */
     public function getDerivativeFilename()
     {
-        $filename = basename($this->filename);
-        $parts = explode('.', $filename);
-        // One or more . in the filename, pop the last section to be replaced.
-        if (count($parts) > 1) {
-            $ext = array_pop($parts);
-        }
-        array_push($parts, self::DERIVATIVE_EXT);
-        return join('.', $parts);
+        $base = pathinfo($this->filename, PATHINFO_EXTENSION) ? substr($this->filename, 0, strrpos($this->filename, '.')) : $this->filename;
+        return $base . '.' . self::DERIVATIVE_EXT;
     }
     
     /**


### PR DESCRIPTION
Hi,

A little patch to normalize the function used to get derivative filename.

The exiting method used to determine the extension is a confusion between the different types of dots, that can be either a normal character in the name of the file, or the separator between the name and the extension of the file.

As there is a php function to determine the extension, pathinfo(), it's better to use it, as in the patch, because it's more standard.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
