### PR TITLE
Update files-form.php

### DIFF
--- a/admin/themes/default/items/files-form.php
+++ b/admin/themes/default/items/files-form.php
@@ -1,3 +1,16 @@
+<div class="add-new"><?php echo __('Add New Files'); ?></div>
+<div class="drawer-contents">
+    <p><?php echo __('The maximum file size is %s.', max_file_size()); ?></p>
+    
+    <div class="field two columns alpha" id="file-inputs">
+        <label><?php echo __('Find a File'); ?></label>
+    </div>
+
+    <div class="files four columns omega">
+        <input name="file[0]" type="file">
+    </div>
+</div>
+
 <?php if (metadata('item', 'has files')): ?>
     <p class="explanation"><?php echo __('Click and drag the files into the preferred display order.'); ?></p>
     <div id="file-list">
@@ -17,18 +30,5 @@
         </ul>
     </div>
 <?php endif; ?>
-
-<div class="add-new"><?php echo __('Add New Files'); ?></div>
-<div class="drawer-contents">
-    <p><?php echo __('The maximum file size is %s.', max_file_size()); ?></p>
-    
-    <div class="field two columns alpha" id="file-inputs">
-        <label><?php echo __('Find a File'); ?></label>
-    </div>
-
-    <div class="files four columns omega">
-        <input name="file[0]" type="file">
-    </div>
-</div>
 
 <?php fire_plugin_hook('admin_items_form_files', array('item' => $item, 'view' => $this)); ?>


### PR DESCRIPTION
By changing order of this form, you can easily add a new file, even if you already have many files associated with the item. You aren't obliger to scroll to the end of the screen to find the "Add files" button.

Going to the bottom of the screen isn't that complicated but when you have a plugin which fires on admin_ites_form_files like Dropbox for example you're sometimes obliged to find this form in the middle of a big screen.
