### PR TITLE
Adds a get_record helper.

### DIFF
--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -1690,6 +1690,21 @@ function get_records($recordType, $params = array(), $limit = 10)
 }
 
 /**
+ * Get a single record from the database.
+ *
+ * @package Omeka\Function\Db
+ * @uses Omeka_Db_Table::findBy
+ * @param string $recordType Type of records to get.
+ * @param array $params Array of search parameters for records.
+ * @return object An object of result records (of $recordType).
+ */
+function get_record($recordType, $params = array())
+{
+    $record = get_records($recordType, $params, 1);
+    return reset($record);
+}
+
+/**
  * Return the total number of a given type of record in the database.
  *
  * @package Omeka\Function\Db


### PR DESCRIPTION
Adds a helper to return a single record object. Arguments are similar to
`get_records` and include:
- $recordType
- $params - An array of search parameters

This makes it a bit easier to query for and use a single record. Instead of
having to do this:

```
$record = get_records('Item', array(), 1);
$record = $record[0];
```

You can use this function:

```
$record = get_record('Item', array());
```

this kind of function was brought up in https://github.com/omeka/Omeka/issues/503#issuecomment-14867491.
