### PR TITLE
Fix Insecure Content Warning

### DIFF
--- a/admin/themes/default/common/login-header.php
+++ b/admin/themes/default/common/login-header.php
@@ -10,7 +10,7 @@
     <?php queue_css_file('layout'); ?>
     <?php queue_css_file('skeleton'); ?>
     <?php echo head_css(); ?>
-    <link href='http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 
     <!-- JavaScripts -->
     <?php

--- a/application/views/scripts/error/index.php
+++ b/application/views/scripts/error/index.php
@@ -11,7 +11,7 @@
     <link rel="stylesheet" media="all" href="<?php echo WEB_VIEW_SCRIPTS . '/css/style.css'; ?>">
     <link rel="stylesheet" media="all" href="<?php echo WEB_VIEW_SCRIPTS . '/css/skeleton.css'; ?>">
     <link rel="stylesheet" media="all" href="<?php echo WEB_VIEW_SCRIPTS . '/css/layout.css'; ?>">
-    <link href='http://fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Arvo:400,700,400italic,700italic|Cabin:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
 </head>
 <body id="debug">
     <div class="container container-sixteen">

--- a/application/views/scripts/functions.php
+++ b/application/views/scripts/functions.php
@@ -27,7 +27,7 @@ function admin_bar() {
  * Styles for admin bar.
  */
 function admin_bar_css() {
-    queue_css_url('http://fonts.googleapis.com/css?family=Arvo:400', 'screen');
+    queue_css_url('//fonts.googleapis.com/css?family=Arvo:400', 'screen');
     queue_css_file('admin-bar', 'screen');
 }
 


### PR DESCRIPTION
Removed the http:// from the non https:// links and changed to the agnostic // style. Where it will pick the transport layer that is being used for browsing.

If browing http:// it will assume http://. If browing https:// it will assume https://
