### PR TITLE
Added possibility to create more types of derivative images, with any effects

### DIFF
--- a/application/controllers/AppearanceController.php
+++ b/application/controllers/AppearanceController.php
@@ -33,7 +33,6 @@ class AppearanceController extends Omeka_Controller_AbstractActionController
         $derivative_types = get_option('derivative_types');
         if (empty($derivative_types)) {
             $derivative_types = array(
-                'original',
                 'fullsize',
                 'thumbnail',
                 'square_thumbnail',
@@ -45,9 +44,16 @@ class AppearanceController extends Omeka_Controller_AbstractActionController
             set_option('square_thumbnail_path', 'square_thumbnails');
             set_option('square_thumbnail_constraint_square', true);
             delete_option('storage_paths');
+            delete_option('original_constraint');
+            delete_option('original_constraint_square');
         }
         else {
             $derivative_types = unserialize($derivative_types);
+            // Original is not a derivative!
+            unset($derivative_types['original']);
+            set_option('derivative_types', serialize($derivative_types));
+            delete_option('original_constraint');
+            delete_option('original_constraint_square');
         }
 
         require_once APP_DIR . '/forms/AppearanceSettings.php';
@@ -55,6 +61,7 @@ class AppearanceController extends Omeka_Controller_AbstractActionController
         $form->setDefaults($this->getInvokeArg('bootstrap')->getResource('Options'));
 
         // TODO Integrate storage paths and constraints with other base options.
+        $form->setDefault('original_path', get_option('original_path'));
         foreach ($derivative_types as $type) {
             $form->setDefault($type . '_path', get_option($type . '_path'));
             $form->setDefault($type . '_constraint', get_option($type . '_constraint'));


### PR DESCRIPTION
Hi,

I need to add another type of derivative image (a thumbnail of intermediate size with some effects).

Fortunately, all the code is ready for that in the core of Omeka: there is method to add derivative types to an uploaded file and a class Omeka_File_Derivative_Image_Creator.

Unfortunately, Omeka won't manage this new derivatives (creation and deletion) because they will not be a standard one. The problem is that the default derivatives are hard coded in application/models/File.php ($_pathsByType = [original, fullsize, thumbnails, square_thumbnails] and in the function createDerivatives() application/model/Files.

So I made a basic patch (see github) to make it more flexible. It:
- makes the PathsByType a function that get list of derivatives from database,
- adds an option in the appearance to list current derivatives and new ones, with their parameters,

The patch is not finalized (it should be integrated in the installer and in the bootstrap), but it is working. You just need to apply the patch and change options in Appearance > Parameters.

Do you think it's usefull or if there is a better way to do that?

I cross-post the patch on Github and Google, because I don't know where it is the better to talk about that.

Sincerely,
## 

Daniel Berthereau
Infodoc & Knowledge management
