### PR TITLE
Allowed to filter by original filename.

### DIFF
--- a/application/models/Table/File.php
+++ b/application/models/Table/File.php
@@ -36,6 +36,10 @@ class Table_File extends Omeka_Db_Table
                     }
                     break;
                     
+                case 'original_filename':
+                    $select->where('files.original_filename = ?', $paramValue);
+                    break;
+
                 case 'size_greater_then':
                     $select->where('files.size > ?', $paramValue);
                     break;


### PR DESCRIPTION
Hi,

Is there any reason why filter or search by original filename is forbidden?

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
