### PR TITLE
Added a call to parent search filters.

### DIFF
--- a/application/models/Table/Collection.php
+++ b/application/models/Table/Collection.php
@@ -14,6 +14,7 @@ class Table_Collection extends Omeka_Db_Table
     public function applySearchFilters($select, $params)
     {
         $boolean = new Omeka_Filter_Boolean;
+        $genericParams = array();
         foreach ($params as $key => $value) {
             switch ($key) {
                 case 'user':
@@ -38,8 +39,12 @@ class Table_Collection extends Omeka_Db_Table
                     $this->filterByRange($select, $value);
                     break;
                 default:
-                    parent::applySearchFilters($select, array($key => $value));
+                    $genericParams[$key] = $value;
             }
+        }
+
+        if (!empty($genericParams)) {
+            parent::applySearchFilters($select, $genericParams);
         }
     }
 

--- a/application/models/Table/Element.php
+++ b/application/models/Table/Element.php
@@ -180,10 +180,18 @@ class Table_Element extends Omeka_Db_Table
 
         // REST API params.
         if (array_key_exists('name', $params)) {
-            $select->where("elements.name = ?", $params['name']);
+            if (is_array($params['name'])) {
+                $select->where("elements.name IN (?)", $params['name']);
+            } else {
+                $select->where("elements.name = ?", $params['name']);
+            }
         }
         if (array_key_exists('element_set', $params)) {
-            $select->where("elements.element_set_id = ?", $params['element_set']);
+            if (is_array($params['element_set'])) {
+                $select->where("elements.element_set_id IN (?)", $params['element_set']);
+            } else {
+                $select->where("elements.element_set_id = ?", $params['element_set']);
+            }
         }
     }
 

--- a/application/models/Table/File.php
+++ b/application/models/Table/File.php
@@ -16,6 +16,7 @@ class Table_File extends Omeka_Db_Table
     public function applySearchFilters($select, $params)
     {
         $boolean = new Omeka_Filter_Boolean;
+        $genericParams = array();
 
         foreach ($params as $paramName => $paramValue) {
             if ($paramValue === null || (is_string($paramValue) && trim($paramValue) == '')) {
@@ -24,8 +25,7 @@ class Table_File extends Omeka_Db_Table
 
             switch ($paramName) {
                 case 'item':
-                case 'item_id':
-                    $select->where('files.item_id = ?', $paramValue);
+                    $genericParams['item_id'] = $paramValue;
                     break;
 
                 case 'order':
@@ -36,20 +36,12 @@ class Table_File extends Omeka_Db_Table
                     }
                     break;
 
-                case 'original_filename':
-                    $select->where('files.original_filename = ?', $paramValue);
-                    break;
-
                 case 'size_greater_then':
                     $select->where('files.size > ?', $paramValue);
                     break;
 
                 case 'has_derivative_image':
                     $this->filterByHasDerivativeImage($select, $boolean->filter($paramValue));
-                    break;
-
-                case 'mime_type':
-                    $select->where('files.mime_type = ?', $paramValue);
                     break;
 
                 case 'added_since':
@@ -61,8 +53,12 @@ class Table_File extends Omeka_Db_Table
                     break;
 
                 default:
-                    parent::applySearchFilters($select, array($key => $value));
+                    $genericParams[$paramName] = $paramValue;
             }
+        }
+
+        if (!empty($genericParams)) {
+            parent::applySearchFilters($select, $genericParams);
         }
     }
 

--- a/application/models/Table/Item.php
+++ b/application/models/Table/Item.php
@@ -383,6 +383,8 @@ class Table_Item extends Omeka_Db_Table
     public function applySearchFilters($select, $params)
     {
         $boolean = new Omeka_Filter_Boolean;
+        $genericParams = array();
+
         foreach ($params as $key => $value) {
             if ($value === null || (is_string($value) && trim($value) == '')) {
                 continue;
@@ -429,10 +431,14 @@ class Table_Item extends Omeka_Db_Table
                     $this->filterBySince($select, $value, 'modified');
                     break;
                 default:
-                    parent::applySearchFilters($select, array($key => $value));
+                    $genericParams[$key] = $value;
             }
         }
         $this->filterBySearch($select, $params);
+
+        if (!empty($genericParams)) {
+            parent::applySearchFilters($select, $genericParams);
+        }
 
         // If we returning the data itself, we need to group by the item ID
         $select->group('items.id');

--- a/application/models/Table/Plugin.php
+++ b/application/models/Table/Plugin.php
@@ -16,16 +16,20 @@ class Table_Plugin extends Omeka_Db_Table
     public function applySearchFilters($select, $params)
     {
         $alias = $this->getTableAlias();
-        if (isset($params['name'])) {
-            $select->where("`$alias`.`name` = ?", $params['name']);
+        $boolean = new Omeka_Filter_Boolean;
+        $genericParams = array();
+
+        foreach ($params as $key => $value) {
+            switch ($key) {
+                case 'active':
+                    $select->where("`$alias`.`active` = ?", $boolean->filter($value));
+                    break;
+                default:
+                    $genericParams[$key] = $value;
+            }
         }
-        if (isset($params['active'])) {
-            $boolean = new Omeka_Filter_Boolean;
-            $select->where("`$alias`.`active` = ?", $boolean->filter($params['active']));
-        }
-        if (isset($params['version'])) {
-            $boolean = new Omeka_Filter_Boolean;
-            $select->where("`$alias`.`version` = ?", $params['version']);
+        if (!empty($genericParams)) {
+            parent::applySearchFilters($select, $genericParams);
         }
     }
 


### PR DESCRIPTION
Hi,

Some columns cannot be filtered, in particular the "id" column. So you can add either a case for it, either a call to parent method, as in this patch.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
