### PR TITLE
Wrap citation URL in span tag for CSS selection

### DIFF
--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -478,7 +478,7 @@ class Item extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
         }
         
         $accessed = format_date(time(), Zend_Date::DATE_LONG);
-        $url = html_escape(record_url($this, null, true));
+        $url = '<span class="citation-url">'.html_escape(record_url($this, null, true)).'</span>';
         /// Chicago-style item citation: access date and URL
         $citation .= __('accessed %1$s, %2$s.', $accessed, $url);
         


### PR DESCRIPTION
Because many Omeka sites exist in subdomains or subdirectories, their URLs tend to be rather long. This creates issues for designers as it can break responsive layouts when the URL is so long that it exceeds the width of the container or viewport. 

Wrapping the citation URL in a span allows a designer to apply CSS styles forcing the URL to wrap lines. For example:

`.citation-url{-ms-word-break:break-all;word-break:break-all;word-break:break-word;-webkit-hyphens:auto;-moz-hyphens:auto;hyphens:auto}`