### PR TITLE
Added a filter for full text indexation of elements.

### DIFF
--- a/application/models/Mixin/ElementText.php
+++ b/application/models/Mixin/ElementText.php
@@ -96,7 +96,8 @@ class Mixin_ElementText extends Omeka_Record_Mixin_AbstractMixin
         if ($titles) {
             $this->_record->setSearchTextTitle($titles[0]->text);
         }
-        foreach ($this->getAllElementTexts() as $elementText) {
+        $elementTexts = apply_filters('index_elements', $this->getAllElementTexts());
+        foreach ($elementTexts as $elementText) {
             $this->_record->addSearchText($elementText->text);
         }
     }

--- a/application/models/Mixin/ElementText.php
+++ b/application/models/Mixin/ElementText.php
@@ -96,7 +96,7 @@ class Mixin_ElementText extends Omeka_Record_Mixin_AbstractMixin
         if ($titles) {
             $this->_record->setSearchTextTitle($titles[0]->text);
         }
-        $elementTexts = apply_filters('index_elements', $this->getAllElementTexts());
+        $elementTexts = apply_filters('search_element_texts', $this->getAllElementTexts());
         foreach ($elementTexts as $elementText) {
             $this->_record->addSearchText($elementText->text);
         }


### PR DESCRIPTION
Hi,

This one line patch adds a filter to modify full text indexation. This is needed for example to remove some fields, specially internal and management ones, from full text search (see https://groups.google.com/forum/#!topic/omeka-dev/cMPhwyvh75M). This can be used with the patch of the plugin Hide Elements (https://github.com/zerocrates/HideElements/pull/8). 

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
