### PR TITLE
Fixed addition of a tag with a different case.

### DIFF
--- a/application/models/Table/Tag.php
+++ b/application/models/Table/Tag.php
@@ -17,7 +17,7 @@ class Table_Tag extends Omeka_Db_Table
         $sql = "
         SELECT tags.* 
         FROM {$db->Tag} tags
-        WHERE tags.name COLLATE utf8_bin LIKE ? 
+        WHERE tags.name LIKE ?
         LIMIT 1";
         $tag = $this->fetchObject($sql, array($name));
         


### PR DESCRIPTION
Hi,

There is an issue when adding a tag to an item, then adding the same tag with a different case. Currently, `Table_Tag::findOrNew()` searches for a collate utf8_bin one, but `AbstractRecord::fieldIsUnique()` searches for a case-insensitive one. This is a solution to this issue, but another one can be done if tag should be sensitive.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
