### PR TITLE
Consistently show selected tags in search filter

### DIFF
--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -3098,7 +3098,7 @@ function tag_string($recordOrTags = null, $link = 'items/browse', $delimiter = n
         if (!$link) {
             $tagStrings[] = html_escape($name);
         } else {
-            $tagStrings[] = '<a href="' . html_escape(url($link, array('tag' => $name))) . '" rel="tag">' . html_escape($name) . '</a>';
+            $tagStrings[] = '<a href="' . html_escape(url($link, array('tags' => $name))) . '" rel="tag">' . html_escape($name) . '</a>';
         }
     }
     return join(html_escape($delimiter), $tagStrings);


### PR DESCRIPTION
Changed tag_string to match tags selected from tag cloud. This ensures that tags selected from the Item Browse or Item Show pages are displayed in the Item Search Filter.

I had originally just added "tag" to ItemSearchFilter, but changing the global tag_string will be helpful in filtering exhibits, too.