### PR TITLE
Fixed getAllElementTextsByElement() for mixin ElementText.

### DIFF
--- a/application/models/Mixin/ElementText.php
+++ b/application/models/Mixin/ElementText.php
@@ -240,7 +240,7 @@ class Mixin_ElementText extends Omeka_Record_Mixin_AbstractMixin
             $this->loadElementsAndTexts();
         }
 
-        return $this->_textsByElementId();
+        return $this->_textsByElementId;
     }
     
     /**


### PR DESCRIPTION
Hi,

A quick fix.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management