### PR TITLE
Plural forms translation

### DIFF
--- a/admin/themes/default/index.php
+++ b/admin/themes/default/index.php
@@ -2,16 +2,22 @@
 $pageTitle = __('Dashboard');
 echo head(array('bodyclass'=>'index primary-secondary', 'title'=>$pageTitle)); ?>
     
-<?php $stats = array(
-    array(link_to('items', null, total_records('Item')), __('items')),
-    array(link_to('collections', null, total_records('Collection')), __('collections')),
-    array(link_to('tags', null, total_records('Tag')), __('tags'))
+<?php
+$total_items = total_records('Item');
+$total_collections = total_records('Collection');
+$total_tags = total_records('Tag');
+$stats = array(
+    array(link_to('items', null, $total_items), __(plural('item', 'items', $total_items))),
+    array(link_to('collections', null, $total_collections), __(plural('collection', 'collections', $total_collections))),
+    array(link_to('tags', null, $total_tags), __(plural('tag', 'tags', $total_tags)))
 ); ?>
 <?php if (is_allowed('Plugins', 'edit')):
-    $stats[] = array(link_to('plugins', null, total_records('Plugin')), __('plugins'));
+    $total_plugins = total_records('Plugin');
+    $stats[] = array(link_to('plugins', null, $total_plugins), __(plural('plugin', 'plugins', $total_plugins)));
 endif; ?>
 <?php if (is_allowed('Users', 'edit')):
-    $stats[] = array(link_to('users', null, total_records('User')), __('users'));
+    $total_users = total_records('User');
+    $stats[] = array(link_to('users', null, $total_users), __(plural('user', 'users', $total_users)));
 endif; ?>
 <?php if (is_allowed('Themes', 'edit')):
     $themeName = Theme::getTheme(Theme::getCurrentThemeName('public'))->title;

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -144,14 +144,18 @@ echo item_search_filters();
     </script>
 
 <?php else: ?>
-    <?php if (total_records('Item') === 0): ?>
+    <?php $total_items = total_records('Item'); ?>
+    <?php if ($total_items === 0): ?>
         <h2><?php echo __('You have no items.'); ?></h2>
         <?php if(is_allowed('Items', 'add')): ?>
             <p><?php echo __('Get started by adding your first item.'); ?></p>
             <a href="<?php echo html_escape(url('items/add')); ?>" class="add big green button"><?php echo __('Add an Item'); ?></a>
         <?php endif; ?>
     <?php else: ?>
-        <p><?php echo __('The query searched %s items and returned no results.', total_records('Item')); ?> <?php echo __('Would you like to %s?', link_to_item_search(__('refine your search'))); ?></p>
+        <p>
+            <?php echo __(plural('The query searched 1 item and returned no results.', 'The query searched %s items and returned no results.', $total_items), $total_items); ?>
+            <?php echo __('Would you like to %s?', link_to_item_search(__('refine your search'))); ?>
+        </p>
     <?php endif; ?>
 <?php endif; ?>
 

--- a/application/languages/Omeka.pot
+++ b/application/languages/Omeka.pot
@@ -362,7 +362,7 @@ msgstr ""
 #: admin/themes/default/element-sets/edit.php:41
 #: admin/themes/default/files/edit.php:35
 #: admin/themes/default/item-types/edit.php:18
-#: admin/themes/default/items/batch-edit.php:130
+#: admin/themes/default/items/batch-edit.php:131
 #: admin/themes/default/items/edit.php:19
 #: admin/themes/default/plugins/config.php:14
 #: admin/themes/default/settings/edit-api.php:82
@@ -399,7 +399,7 @@ msgstr ""
 #: admin/themes/default/files/show.php:30
 #: admin/themes/default/item-types/edit.php:20
 #: admin/themes/default/item-types/show.php:54
-#: admin/themes/default/items/batch-edit.php:119
+#: admin/themes/default/items/batch-edit.php:120
 #: admin/themes/default/items/browse.php:27
 #: admin/themes/default/items/browse.php:81
 #: admin/themes/default/items/browse.php:123
@@ -439,7 +439,7 @@ msgstr ""
 #: admin/themes/default/collections/edit.php:30
 #: admin/themes/default/collections/show.php:41
 #: admin/themes/default/items/add.php:19
-#: admin/themes/default/items/batch-edit.php:50
+#: admin/themes/default/items/batch-edit.php:51
 #: admin/themes/default/items/edit.php:28
 #: admin/themes/default/items/quick-filters.php:6
 #: admin/themes/default/items/show.php:52
@@ -450,7 +450,7 @@ msgstr ""
 #: admin/themes/default/collections/edit.php:35
 #: admin/themes/default/collections/show.php:42
 #: admin/themes/default/items/add.php:25
-#: admin/themes/default/items/batch-edit.php:65
+#: admin/themes/default/items/batch-edit.php:66
 #: admin/themes/default/items/edit.php:34
 #: admin/themes/default/items/quick-filters.php:8
 #: admin/themes/default/items/show.php:53
@@ -510,8 +510,8 @@ msgstr ""
 #: admin/themes/default/collections/show.php:32
 #: admin/themes/default/element-sets/browse.php:27
 #: admin/themes/default/error/404.php:24 admin/themes/default/error/404.php:45
-#: admin/themes/default/files/show.php:26 admin/themes/default/index.php:54
-#: admin/themes/default/index.php:73
+#: admin/themes/default/files/show.php:26 admin/themes/default/index.php:60
+#: admin/themes/default/index.php:79
 #: admin/themes/default/item-types/browse.php:26
 #: admin/themes/default/item-types/show.php:51
 #: admin/themes/default/items/browse.php:24
@@ -671,7 +671,6 @@ msgstr ""
 
 #: admin/themes/default/common/header.php:11
 #: admin/themes/default/upgrade/index.php:6
-#: admin/themes/default/upgrade/migrate.php:6
 #: application/views/scripts/common/admin-bar.php:11
 msgid "Omeka Admin"
 msgstr ""
@@ -703,10 +702,9 @@ msgstr ""
 
 #: admin/themes/default/common/settings-nav.php:16
 #: admin/themes/default/search/index.php:2
-#: application/views/helpers/SearchForm.php:34
+#: application/views/helpers/SearchForm.php:56
 #: application/views/scripts/search/index.php:2
 #: application/views/scripts/search/search-form.php:2
-#: application/views/scripts/search/search-form.php:22
 msgid "Search"
 msgstr ""
 
@@ -786,19 +784,19 @@ msgstr ""
 msgid "If this does not help, try contacting the %s."
 msgstr ""
 
-#: admin/themes/default/error/404.php:16 admin/themes/default/index.php:46
+#: admin/themes/default/error/404.php:16 admin/themes/default/index.php:52
 msgid "Recent Items"
 msgstr ""
 
-#: admin/themes/default/error/404.php:29 admin/themes/default/index.php:59
+#: admin/themes/default/error/404.php:29 admin/themes/default/index.php:65
 msgid "Add a new item"
 msgstr ""
 
-#: admin/themes/default/error/404.php:36 admin/themes/default/index.php:64
+#: admin/themes/default/error/404.php:36 admin/themes/default/index.php:70
 msgid "Recent Collections"
 msgstr ""
 
-#: admin/themes/default/error/404.php:50 admin/themes/default/index.php:78
+#: admin/themes/default/error/404.php:50 admin/themes/default/index.php:84
 msgid "Add a new collection"
 msgstr ""
 
@@ -914,35 +912,45 @@ msgstr ""
 msgid "Output Formats"
 msgstr ""
 
-#: admin/themes/default/index.php:6
-msgid "items"
-msgstr ""
-
-#: admin/themes/default/index.php:7
-msgid "collections"
-msgstr ""
-
-#: admin/themes/default/index.php:8
-msgid "tags"
-msgstr ""
+#: admin/themes/default/index.php:10
+msgid "item"
+msgid_plural "items"
+msgstr[0] ""
+msgstr[1] ""
 
 #: admin/themes/default/index.php:11
-msgid "plugins"
-msgstr ""
+msgid "collection"
+msgid_plural "collections"
+msgstr[0] ""
+msgstr[1] ""
 
-#: admin/themes/default/index.php:14
-msgid "users"
-msgstr ""
+#: admin/themes/default/index.php:12
+msgid "tag"
+msgid_plural "tags"
+msgstr[0] ""
+msgstr[1] ""
 
-#: admin/themes/default/index.php:18
+#: admin/themes/default/index.php:16
+msgid "plugin"
+msgid_plural "plugins"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/themes/default/index.php:20
+msgid "user"
+msgid_plural "users"
+msgstr[0] ""
+msgstr[1] ""
+
+#: admin/themes/default/index.php:24
 msgid "theme"
 msgstr ""
 
-#: admin/themes/default/index.php:29
+#: admin/themes/default/index.php:35
 msgid "A new version of Omeka is available for download."
 msgstr ""
 
-#: admin/themes/default/index.php:30
+#: admin/themes/default/index.php:36
 #, php-format
 msgid "Upgrade to %s"
 msgstr ""
@@ -1042,7 +1050,7 @@ msgstr ""
 #: admin/themes/default/items/add.php:2
 #: admin/themes/default/items/browse.php:20
 #: admin/themes/default/items/browse.php:116
-#: admin/themes/default/items/browse.php:151
+#: admin/themes/default/items/browse.php:152
 msgid "Add an Item"
 msgstr ""
 
@@ -1051,7 +1059,7 @@ msgid "Add Item"
 msgstr ""
 
 #: admin/themes/default/items/add.php:32
-#: admin/themes/default/items/batch-edit.php:89
+#: admin/themes/default/items/batch-edit.php:90
 #: admin/themes/default/items/browse.php:90
 #: admin/themes/default/items/edit.php:41
 #: admin/themes/default/items/show.php:57
@@ -1074,7 +1082,7 @@ msgid "Checked items will be deleted."
 msgstr ""
 
 #: admin/themes/default/items/batch-delete.php:50
-#: admin/themes/default/items/batch-edit.php:116
+#: admin/themes/default/items/batch-edit.php:117
 msgid "Delete Items"
 msgstr ""
 
@@ -1082,59 +1090,59 @@ msgstr ""
 msgid "Batch Edit Items"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:36
+#: admin/themes/default/items/batch-edit.php:37
 msgid "Changes will be applied to checked items."
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:41
+#: admin/themes/default/items/batch-edit.php:42
 msgid "Item Metadata"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:46
+#: admin/themes/default/items/batch-edit.php:47
 msgid "Public?"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:49
-#: admin/themes/default/items/batch-edit.php:64
-#: admin/themes/default/items/batch-edit.php:78
-#: admin/themes/default/items/batch-edit.php:93
+#: admin/themes/default/items/batch-edit.php:50
+#: admin/themes/default/items/batch-edit.php:65
+#: admin/themes/default/items/batch-edit.php:79
+#: admin/themes/default/items/batch-edit.php:94
 msgid "Select Below"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:51
+#: admin/themes/default/items/batch-edit.php:52
 msgid "Not Public"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:61
+#: admin/themes/default/items/batch-edit.php:62
 msgid "Featured?"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:66
+#: admin/themes/default/items/batch-edit.php:67
 msgid "Not Featured"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:74
+#: admin/themes/default/items/batch-edit.php:75
 #: admin/themes/default/items/item-type-form.php:3
 msgid "Item Type"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:83
-#: admin/themes/default/items/batch-edit.php:98
+#: admin/themes/default/items/batch-edit.php:84
+#: admin/themes/default/items/batch-edit.php:99
 msgid "Remove?"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:104
+#: admin/themes/default/items/batch-edit.php:105
 #: admin/themes/default/items/tag-form.php:8
 #: admin/themes/default/items/tag-form.php:11
 msgid "Add Tags"
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:107
+#: admin/themes/default/items/batch-edit.php:108
 #, php-format
 msgid "List of tags to add to all checked items, separated by %s."
 msgstr ""
 
-#: admin/themes/default/items/batch-edit.php:117
+#: admin/themes/default/items/batch-edit.php:118
 msgid "Check if you wish to delete selected items."
 msgstr ""
 
@@ -1182,8 +1190,8 @@ msgstr ""
 #: admin/themes/default/items/browse.php:22
 #: admin/themes/default/items/browse.php:118
 #: admin/themes/default/items/search.php:2
-#: application/libraries/globals.php:2367
-#: application/libraries/globals.php:2757
+#: application/libraries/globals.php:2391
+#: application/libraries/globals.php:2781
 #: application/views/scripts/items/search.php:2
 msgid "Search Items"
 msgstr ""
@@ -1208,24 +1216,26 @@ msgstr ""
 msgid "Hide Details"
 msgstr ""
 
-#: admin/themes/default/items/browse.php:148
+#: admin/themes/default/items/browse.php:149
 msgid "You have no items."
 msgstr ""
 
-#: admin/themes/default/items/browse.php:150
+#: admin/themes/default/items/browse.php:151
 msgid "Get started by adding your first item."
 msgstr ""
 
-#: admin/themes/default/items/browse.php:154
+#: admin/themes/default/items/browse.php:156
 #, php-format
-msgid "The query searched %s items and returned no results."
-msgstr ""
+msgid "The query searched 1 item and returned no results."
+msgid_plural "The query searched %s items and returned no results."
+msgstr[0] ""
+msgstr[1] ""
 
-#: admin/themes/default/items/browse.php:154
+#: admin/themes/default/items/browse.php:157
 msgid "refine your search"
 msgstr ""
 
-#: admin/themes/default/items/browse.php:154
+#: admin/themes/default/items/browse.php:157
 #, php-format
 msgid "Would you like to %s?"
 msgstr ""
@@ -1773,27 +1783,27 @@ msgstr ""
 msgid "Upgrade Database"
 msgstr ""
 
-#: admin/themes/default/upgrade/migrate.php:32
+#: admin/themes/default/upgrade/migrate.php:3
+msgid "Omeka has upgraded successfully."
+msgstr ""
+
+#: admin/themes/default/upgrade/migrate.php:5
 msgid "Omeka encountered an error when upgrading your installation."
 msgstr ""
 
-#: admin/themes/default/upgrade/migrate.php:37
+#: admin/themes/default/upgrade/migrate.php:24
+msgid "Return to Dashboard"
+msgstr ""
+
+#: admin/themes/default/upgrade/migrate.php:29
 msgid "Please restore from your database backup and try again."
 msgstr ""
 
-#: admin/themes/default/upgrade/migrate.php:39
+#: admin/themes/default/upgrade/migrate.php:30
 msgid ""
 "If you have any questions please refer to <a href=\"http://omeka.org/codex"
 "\">Omeka documentation</a> or post a message on the <a href=\"http://omeka."
 "org/forums\">Omeka forums</a>."
-msgstr ""
-
-#: admin/themes/default/upgrade/migrate.php:42
-msgid "Omeka has upgraded successfully."
-msgstr ""
-
-#: admin/themes/default/upgrade/migrate.php:43
-msgid "Return to Dashboard"
 msgstr ""
 
 #: admin/themes/default/users/activate.php:2
@@ -2341,7 +2351,7 @@ msgstr ""
 msgid "The theme settings were successfully saved!"
 msgstr ""
 
-#: application/controllers/UpgradeController.php:50
+#: application/controllers/UpgradeController.php:48
 msgid "SQL error in migration: "
 msgstr ""
 
@@ -2950,65 +2960,65 @@ msgstr ""
 msgid "Exact match"
 msgstr ""
 
-#: application/libraries/globals.php:1234
-#: application/libraries/globals.php:1255
+#: application/libraries/globals.php:1258
+#: application/libraries/globals.php:1279
 #, php-format
 msgid "Could not find file %s!"
 msgstr ""
 
-#: application/libraries/globals.php:1272
+#: application/libraries/globals.php:1296
 msgid "No featured collections are available."
 msgstr ""
 
-#: application/libraries/globals.php:1564
+#: application/libraries/globals.php:1588
 msgid "Select Below "
 msgstr ""
 
-#: application/libraries/globals.php:1607
+#: application/libraries/globals.php:1631
 msgid "Omeka RSS Feed"
 msgstr ""
 
-#: application/libraries/globals.php:1608
+#: application/libraries/globals.php:1632
 msgid "Omeka Atom Feed"
 msgstr ""
 
-#: application/libraries/globals.php:2264
+#: application/libraries/globals.php:2288
 msgid "No recent items available."
 msgstr ""
 
-#: application/libraries/globals.php:2290
+#: application/libraries/globals.php:2314
 msgid "No featured items are available."
 msgstr ""
 
-#: application/libraries/globals.php:2349
+#: application/libraries/globals.php:2373
 msgid "View"
 msgstr ""
 
-#: application/libraries/globals.php:2411
+#: application/libraries/globals.php:2435
 msgid "No Collection"
 msgstr ""
 
-#: application/libraries/globals.php:2529
+#: application/libraries/globals.php:2553
 msgid "RSS"
 msgstr ""
 
-#: application/libraries/globals.php:2546
+#: application/libraries/globals.php:2570
 msgid "Next Item &rarr;"
 msgstr ""
 
-#: application/libraries/globals.php:2566
+#: application/libraries/globals.php:2590
 msgid "&larr; Previous Item"
 msgstr ""
 
-#: application/libraries/globals.php:2747
+#: application/libraries/globals.php:2771
 msgid "Browse All"
 msgstr ""
 
-#: application/libraries/globals.php:2752
+#: application/libraries/globals.php:2776
 msgid "Browse by Tag"
 msgstr ""
 
-#: application/libraries/globals.php:3021
+#: application/libraries/globals.php:3045
 msgid "No tags are available."
 msgstr ""
 
@@ -3121,62 +3131,62 @@ msgstr ""
 msgid "The item type name must be unique."
 msgstr ""
 
-#: application/models/ItemType.php:179
+#: application/models/ItemType.php:183
 msgid "There are too many values in the element ordering array."
 msgstr ""
 
-#: application/models/ItemType.php:181
+#: application/models/ItemType.php:185
 msgid "There are too few values in the element ordering array."
 msgstr ""
 
-#: application/models/ItemType.php:218
+#: application/models/ItemType.php:222
 msgid ""
 "Invalid element data. To add elements, you must either pass an element "
 "objects or an array of element metadata."
 msgstr ""
 
-#: application/models/ItemType.php:282
+#: application/models/ItemType.php:286
 msgid ""
 "Cannot remove elements from an item type that is not persistent in the "
 "database!"
 msgstr ""
 
-#: application/models/ItemType.php:291
+#: application/models/ItemType.php:295
 #, php-format
 msgid "Cannot find element with ID %s!"
 msgstr ""
 
-#: application/models/ItemType.php:332
+#: application/models/ItemType.php:336
 #, php-format
 msgid "Item type does not contain an element with the ID %s!"
 msgstr ""
 
-#: application/models/ItemType.php:353
+#: application/models/ItemType.php:357
 msgid ""
 "Invalid parameter. The hasElement function requires either an element object "
 "or an element id to determine if an item type has an element."
 msgstr ""
 
-#: application/models/Mixin/ElementText.php:292
+#: application/models/Mixin/ElementText.php:293
 #, php-format
 msgid "There is no element \"%1$s\", \"%2$s\"!"
 msgstr ""
 
-#: application/models/Mixin/ElementText.php:311
+#: application/models/Mixin/ElementText.php:312
 #, php-format
 msgid "Cannot find an element with an ID of '%s'!"
 msgstr ""
 
-#: application/models/Mixin/ElementText.php:430
+#: application/models/Mixin/ElementText.php:431
 msgid "Element texts are not formatted correctly!"
 msgstr ""
 
-#: application/models/Mixin/ElementText.php:578
+#: application/models/Mixin/ElementText.php:579
 #, php-format
 msgid "The \"%s\" field has at least one invalid value!"
 msgstr ""
 
-#: application/models/Mixin/ElementText.php:648
+#: application/models/Mixin/ElementText.php:649
 msgid "Cannot save element text for records that are not yet persistent!"
 msgstr ""
 

--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -875,12 +875,13 @@ function plugin_is_active($name, $version = null, $compOperator = '>=')
  *
  * @package Omeka\Function\Locale
  * @uses Zend_Translate::translate()
- * @param string $string The string to be translated.
+ * @param string|array $msgid The string to be translated, or Array for plural
+ *  translations.
  * @param mixed $args string formatting args. If any extra args are passed, the
  *  args and the translated string will be formatted with sprintf().
  * @return string The translated string.
  */
-function __($string)
+function __($msgid)
 {
     // Avoid getting the translate object more than once.
     static $translate;
@@ -894,7 +895,11 @@ function __($string)
     }
 
     if ($translate) {
-        $string = $translate->translate($string);
+        $string = $translate->translate($msgid);
+    } elseif (is_array($msgid)) {
+      $string = $msgid[0];
+    } else {
+      $string = $msgid;
     }
 
     $args = func_get_args();
@@ -905,6 +910,25 @@ function __($string)
     }
 
     return $string;
+}
+
+/**
+ * Transform arguments in an array suitable for __.
+ *
+ * <code>
+ *     $n = count($items);
+ *     echo __(plural('one item', '%s items', $n), $n);
+ * </code>
+ *
+ * @package Omeka\Function\Locale
+ * @param string $msgid The string to be translated, singular form
+ * @param string $msgid_plural The string to be translated, plural form
+ * @param int $n Used to determine the plural form
+ * @return array Array to pass to __
+ */
+function plural($msgid, $msgid_plural, $n)
+{
+    return array($msgid, $msgid_plural, $n);
 }
 
 /**

--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -897,9 +897,9 @@ function __($msgid)
     if ($translate) {
         $string = $translate->translate($msgid);
     } elseif (is_array($msgid)) {
-      $string = $msgid[0];
+        $string = ($msgid[2] === 1) ? $msgid[0] : $msgid[1];
     } else {
-      $string = $msgid;
+        $string = $msgid;
     }
 
     $args = func_get_args();

--- a/build.xml
+++ b/build.xml
@@ -75,6 +75,7 @@
             <arg value="--language=php"/>
             <arg value="--from-code=utf-8"/>
             <arg value="--keyword=__"/>
+            <arg value="--keyword=plural:1,2"/>
             <arg value="--flag=__:1:pass-php-format"/>
             <arg value="--add-comments=/"/>
             <arg value="--omit-header"/>


### PR DESCRIPTION
Hi,

a simple patch to allow plural forms translation.

Used like this:

```php
__(plural('one item', '%s items', $n), $n);
```