### PR TITLE
Addded 'starts with/ends with' advanced search options

### DIFF
--- a/admin/themes/default/items/search-form.php
+++ b/admin/themes/default/items/search-form.php
@@ -73,7 +73,9 @@ $formAttributes['method'] = 'GET';
                         'does not contain' => __('does not contain'),
                         'is exactly' => __('is exactly'),
                         'is empty' => __('is empty'),
-                        'is not empty' => __('is not empty'))
+                        'is not empty' => __('is not empty'),
+                        'starts with' => __('starts with'),
+                        'ends with' => __('ends with'))
                     )
                 );
                 echo $this->formText(

--- a/application/models/Table/Item.php
+++ b/application/models/Table/Item.php
@@ -119,6 +119,12 @@ class Table_Item extends Omeka_Db_Table
                 case 'is not empty':
                     $predicate = "IS NOT NULL";
                     break;
+                case 'starts with':
+                    $predicate = "LIKE " . $db->quote($value.'%');
+                    break;
+                case 'ends with':
+                    $predicate = "LIKE " . $db->quote('%'.$value);
+                    break;
                 default:
                     throw new Omeka_Record_Exception(__('Invalid search type given!'));
             }

--- a/application/views/scripts/items/search-form.php
+++ b/application/views/scripts/items/search-form.php
@@ -69,7 +69,9 @@ $formAttributes['method'] = 'GET';
                         'does not contain' => __('does not contain'),
                         'is exactly' => __('is exactly'),
                         'is empty' => __('is empty'),
-                        'is not empty' => __('is not empty'))
+                        'is not empty' => __('is not empty'),
+                        'starts with' => __('starts with'),
+                        'ends with' => __('ends with'))
                     )
                 );
                 echo $this->formText(


### PR DESCRIPTION
I'm not sure if there are more people who need it, but achieving this simple feature via plugins/hooks/filters is really pain. 
I actually need only *starts with* option, but I'm guessing many will say, and where is *ends with* then? So I addded it for consistency sake as well. 
