### PR TITLE
updated FileMarkup.defaultDisplay to use the linkText option

### DIFF
--- a/application/views/helpers/FileMarkup.php
+++ b/application/views/helpers/FileMarkup.php
@@ -277,10 +277,11 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
      */
     public function defaultDisplay($file, array $options=array())
     {
+        $html = null;
         if ($options['linkText']) {
             $html = $options['linkText'];
         }
-        return $this->_linkToFile($file, $options);
+        return $this->_linkToFile($file, $options, $html);
     }
         
     /**


### PR DESCRIPTION
I was playing around with the FileMarkup helper, trying to get it to generate a text link, e.g.

    $html = $helper->defaultDisplay($file, array('linkText'=> 'Download', 'linkToFile' => true, 'linkToMetadata' => false));

I expected this to generate a link with "Download" as the text. Instead it generated a link with the original file name as the text. Looking at the code, the linkText option was not passed on from defaultDisplay to_linktoFile. I believe this change fixes this problem.