### PR TITLE
Added a button to batch all browsed items.

### DIFF
--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -617,9 +617,9 @@ footer {
         #advanced-form input[type=radio] { margin: 0 9px 0 0; }
 
         #advanced-form input[type=checkbox] { margin-right: 5px; }
-        
+
         #advanced-form fieldset { margin: 20px 0; }
-        
+
         #advanced-form legend {
             font-size: 16px;
             margin: 20px 0 10px;
@@ -1601,6 +1601,7 @@ header nav {
 .table-actions {
     clear: left;
     float: left;
+    width: 100%;
 }
 
     .browse-items .table-actions input[type=submit], .browse-items .table-actions a.button,
@@ -1644,9 +1645,9 @@ header nav {
     box-sizing: border-box;
     color: #666;
     display: inline-block;
-    float: left;
     line-height: 1.5em;
-    margin: 0px 0px 20px 0px;
+    margin: 0 0 0 -3px;
+    vertical-align: top;
     padding: 0;
     z-index: 15;
 }
@@ -1700,6 +1701,79 @@ header nav {
     display: none;
 }
 
+.quick-filters li {
+    display: inline-block;
+    padding: 3px 10px;
+    border-left: 1px solid #d8d8d8;
+}
+
+.quick-filters li a {
+    color: #666;
+}
+
+.quick-filters {
+    float: right;
+    margin: 0;
+    display: inline-block;
+}
+
+.table-actions {
+    background: #f8f8f8;
+    background: -webkit-linear-gradient(top, #f8f8f8, #e2e2e2);
+    background: -moz-linear-gradient(top, #f8f8f8, #e2e2e2);
+    background: -o-linear-gradient(top, #f8f8f8, #e2e2e2);
+    background: linear-gradient(to bottom, #f8f8f8, #e2e2e2);
+    border: 1px solid #D8D8D8;
+    border-bottom: 0;
+    width: 100%;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    text-align: right;
+}
+
+.table-actions > *,
+.table-actions > input[type="submit"].small {
+    margin-bottom: 0;
+    background: none;
+    border: 0;
+    box-shadow: none;
+    color: #666;
+    text-shadow: none;
+}
+
+.table-actions button {
+    float: left;
+    border-right: 1px solid #D8D8D8;
+}
+
+.table-actions button:hover {
+    box-shadow: none;
+    color: #666;
+}
+
+.table-actions button:active,
+.table-actions button.active {
+    background-color: #cecece;
+    color: #545454 !important;
+}
+
+.table-actions .selected {
+    display: inline-block;
+    margin-right: 4px;
+}
+
+.table-actions > input[type="submit"].small {
+    border-left: 1px solid #D8D8D8;
+    display: inline-block;
+    margin-right: 0;
+}
+
+table + .table-actions {
+    margin: -16px 0 20px;
+    border-top: 0;
+    border-bottom: 1px solid #d8d8d8;
+}
 
 /* Show Item
 ================================================== */

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -1598,14 +1598,14 @@ header nav {
     box-sizing: border-box;
 }
 
-.table-actions {
+.items .table-actions {
     clear: left;
     float: left;
     width: 100%;
 }
 
-    .browse-items .table-actions input[type=submit], .browse-items .table-actions a.button,
-    .browse-items .table-actions button {
+    .items .browse-items .table-actions input[type=submit], .browse-items .table-actions a.button,
+    .items .browse-items .table-actions button {
         float: left;
         height: 25px;
     }
@@ -1717,7 +1717,7 @@ header nav {
     display: inline-block;
 }
 
-.table-actions {
+.items .table-actions {
     background: #f8f8f8;
     background: -webkit-linear-gradient(top, #f8f8f8, #e2e2e2);
     background: -moz-linear-gradient(top, #f8f8f8, #e2e2e2);
@@ -1732,8 +1732,8 @@ header nav {
     text-align: right;
 }
 
-.table-actions > *,
-.table-actions > input[type="submit"].small {
+.items .table-actions > *,
+.items .table-actions > input[type="submit"].small {
     margin-bottom: 0;
     background: none;
     border: 0;
@@ -1742,34 +1742,34 @@ header nav {
     text-shadow: none;
 }
 
-.table-actions button {
+.items .table-actions button {
     float: left;
     border-right: 1px solid #D8D8D8;
 }
 
-.table-actions button:hover {
+.itesm .table-actions button:hover {
     box-shadow: none;
     color: #666;
 }
 
-.table-actions button:active,
-.table-actions button.active {
+.items .table-actions button:active,
+.items .table-actions button.active {
     background-color: #cecece;
     color: #545454 !important;
 }
 
-.table-actions .selected {
+.items .table-actions .selected {
     display: inline-block;
     margin-right: 4px;
 }
 
-.table-actions > input[type="submit"].small {
+.items .table-actions > input[type="submit"].small {
     border-left: 1px solid #D8D8D8;
     display: inline-block;
     margin-right: 0;
 }
 
-table + .table-actions {
+.itesm table + .table-actions {
     margin: -16px 0 20px;
     border-top: 0;
     border-bottom: 1px solid #d8d8d8;

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -1747,7 +1747,7 @@ header nav {
     border-right: 1px solid #D8D8D8;
 }
 
-.itesm .table-actions button:hover {
+.items .table-actions button:hover {
     box-shadow: none;
     color: #666;
 }
@@ -1769,7 +1769,7 @@ header nav {
     margin-right: 0;
 }
 
-.itesm table + .table-actions {
+.items table + .table-actions {
     margin: -16px 0 20px;
     border-top: 0;
     border-bottom: 1px solid #d8d8d8;

--- a/admin/themes/default/items/batch-delete-all.php
+++ b/admin/themes/default/items/batch-delete-all.php
@@ -9,7 +9,7 @@ endif;
 ?>
 <div title="<?php echo $title; ?>">
 
-<form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-all-save')); ?>" method="post" accept-charset="utf-8">
+<form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-save')); ?>" method="post" accept-charset="utf-8">
     <section class="seven columns alpha">
         <fieldset class="panel">
             <h2><?php echo __('Search Filters'); ?></h2>
@@ -22,6 +22,7 @@ endif;
             <?php endif; ?>
             <p class="explanation"><?php echo __('Deletions will be processed in the background item by item, so you should check logs for success and errors.'); ?></p>
             <?php
+            echo $this->formHidden('all', true);
             echo $this->formHidden('params', json_encode($params));
             ?>
         </fieldset>

--- a/admin/themes/default/items/batch-delete-all.php
+++ b/admin/themes/default/items/batch-delete-all.php
@@ -1,0 +1,49 @@
+<?php
+$title = __('Batch Delete All Searched Items');
+if (!$isPartial):
+    echo head(array(
+        'title' => $title,
+        'bodyclass' => 'items batch-edit',
+    ));
+endif;
+?>
+<div title="<?php echo $title; ?>">
+
+<form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-all-save')); ?>" method="post" accept-charset="utf-8">
+    <section class="seven columns alpha">
+        <fieldset class="panel">
+            <h2><?php echo __('Search Filters'); ?></h2>
+            <?php if ($params):
+                echo item_search_filters($params); ?>
+            <p class="explanation"><?php echo __('All items matching search filters above will be deleted [%d].', $totalRecords); ?></p>
+            <?php else: ?>
+            <p><?php echo __('No search filter.'); ?></p>
+            <p class="explanation"><?php echo __('All items of the base will be deleted [%d].', $totalRecords); ?></p>
+            <?php endif; ?>
+            <p class="explanation"><?php echo __('Deletions will be processed in the background item by item, so you should check logs for success and errors.'); ?></p>
+            <?php
+            echo $this->formHidden('params', json_encode($params));
+            ?>
+        </fieldset>
+        <input type="hidden" name="delete" value="1">
+    </section>
+
+    <section class="three columns omega">
+        <div  id="save" class="panel">
+            <input type="submit" class="big red button" value="<?php echo __('Delete Items'); ?>">
+        </div>
+    </section>
+
+    <?php
+    $hash = new Zend_Form_Element_Hash('batch_edit_hash');
+    $hash->removeDecorator('Label');
+    $hash->removeDecorator('HtmlTag');
+    echo $hash;
+    ?>
+</form>
+
+</div>
+<?php
+if (!$isPartial):
+    echo foot();
+endif;

--- a/admin/themes/default/items/batch-delete.php
+++ b/admin/themes/default/items/batch-delete.php
@@ -39,6 +39,7 @@ if (!$isPartial):
             <?php endif; ?>
             
             <p class="explanation"><?php echo __('Checked items will be deleted.'); ?></p>
+        </div>
     </fieldset>
 
     <input type="hidden" name="delete" value="1">

--- a/admin/themes/default/items/batch-delete.php
+++ b/admin/themes/default/items/batch-delete.php
@@ -1,49 +1,45 @@
 <?php
 $title = __('Batch Delete Items');
 if (!$isPartial):
-    echo head(array('title' => $title, 
-               'bodyclass' => 'advanced-search', 
-               'bodyid' => 'advanced-search-page'));
+    echo head(array(
+        'title' => $title,
+        'bodyclass' => 'items batch-edit',
+    ));
+endif;
 ?>
-
-<?php endif; ?>
-        
 <div title="<?php echo $title; ?>">
 
 <form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-save')); ?>" method="post" accept-charset="utf-8">
-
     <section class="seven columns alpha">
-    <fieldset id="item-list" class="panel">
-        <h2 class="two columns alpha"><?php echo __('Items'); ?></h2>
-        <div class="five columns omega">
-            <ul>
-            <?php 
-            $itemCheckboxes = array();
-            $excludedItems = false;
-            foreach ($itemIds as $id) {
-                if (!($item = get_record_by_id('item', $id))) {
-                    continue;
-                }
-                
-                if (is_allowed($item, 'delete')) {
-                    $itemCheckboxes[$id] = metadata($item, array('Dublin Core', 'Title'));
-                } else {
-                    $excludedItems = true;
-                }
-                release_object($item);
-            }
-            echo '<li>' . $this->formMultiCheckbox('items[]', null, array('checked' => 'checked'), $itemCheckboxes, '</li><li>') . '</li>'; ?>
-            </ul>
-            <?php if ($excludedItems): ?>
-            <p class="explanation"><?php echo __('Some items were excluded because you do not have permission to delete them.'); ?></p>
-            <?php endif; ?>
-            
-            <p class="explanation"><?php echo __('Checked items will be deleted.'); ?></p>
-        </div>
-    </fieldset>
+        <fieldset id="item-list" class="panel">
+            <h2 class="two columns alpha"><?php echo __('Items'); ?></h2>
+            <div class="five columns omega">
+                <ul>
+                <?php
+                $itemCheckboxes = array();
+                $excludedItems = false;
+                foreach ($itemIds as $id) {
+                    if (!($item = get_record_by_id('item', $id))) {
+                        continue;
+                    }
 
-    <input type="hidden" name="delete" value="1">
-    
+                    if (is_allowed($item, 'delete')) {
+                        $itemCheckboxes[$id] = metadata($item, array('Dublin Core', 'Title'));
+                    } else {
+                        $excludedItems = true;
+                    }
+                    release_object($item);
+                }
+                echo '<li>' . $this->formMultiCheckbox('items[]', null, array('checked' => 'checked'), $itemCheckboxes, '</li><li>') . '</li>'; ?>
+                </ul>
+                <?php if ($excludedItems): ?>
+                <p class="explanation"><?php echo __('Some items were excluded because you do not have permission to delete them.'); ?></p>
+                <?php endif; ?>
+
+                <p class="explanation"><?php echo __('Checked items will be deleted.'); ?></p>
+            </div>
+        </fieldset>
+        <input type="hidden" name="delete" value="1">
     </section>
 
     <section class="three columns omega">
@@ -59,7 +55,9 @@ if (!$isPartial):
     echo $hash;
     ?>
 </form>
+
 </div>
-<?php if (!$isPartial): ?>
-<?php echo foot(); ?>
-<?php endif; ?>
+<?php
+if (!$isPartial):
+    echo foot();
+endif;

--- a/admin/themes/default/items/batch-edit-all.php
+++ b/admin/themes/default/items/batch-edit-all.php
@@ -1,0 +1,54 @@
+<?php
+$title = __('Batch Edit All Searched Items');
+if (!$isPartial):
+    echo head(
+        array(
+            'title' => $title,
+            'bodyclass' => 'items batch-edit',
+        )
+    );
+endif;
+?>
+<div title="<?php echo $title; ?>">
+
+<form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-all-save')); ?>" method="post" accept-charset="utf-8">
+    <section class="seven columns alpha">
+        <fieldset class="panel">
+            <h2><?php echo __('Search Filters'); ?></h2>
+            <?php if ($params):
+                echo item_search_filters($params); ?>
+            <p class="explanation"><?php echo __('Changes will be applied to all items matching search filters above [%d].', $totalRecords); ?></p>
+            <?php else: ?>
+            <p><?php echo __('No search filter.'); ?></p>
+            <p class="explanation"><?php echo __('Changes will be applied to all items of the base [%d].', $totalRecords); ?></p>
+            <?php endif; ?>
+            <p class="explanation"><?php echo __('Changes will be processed in the background item by item, so you should check logs for success and errors.'); ?></p>
+            <?php
+            echo $this->formHidden('params', json_encode($params));
+            ?>
+        </fieldset>
+
+        <?php echo common('batch-edit-common', array(), 'items'); ?>
+
+        <?php fire_plugin_hook('admin_items_batch_edit_form', array('view' => $this)); ?>
+    </section>
+
+    <section class="three columns omega">
+        <div id="save" class="panel">
+            <input type="submit" class="big green button" value="<?php echo __('Save Changes'); ?>">
+        </div>
+    </section>
+
+    <?php
+    $hash = new Zend_Form_Element_Hash('batch_edit_hash');
+    $hash->removeDecorator('Label');
+    $hash->removeDecorator('HtmlTag');
+    echo $hash;
+    ?>
+</form>
+
+</div>
+<?php
+if (!$isPartial):
+    echo foot();
+endif;

--- a/admin/themes/default/items/batch-edit-all.php
+++ b/admin/themes/default/items/batch-edit-all.php
@@ -11,7 +11,7 @@ endif;
 ?>
 <div title="<?php echo $title; ?>">
 
-<form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-all-save')); ?>" method="post" accept-charset="utf-8">
+<form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-save')); ?>" method="post" accept-charset="utf-8">
     <section class="seven columns alpha">
         <fieldset class="panel">
             <h2><?php echo __('Search Filters'); ?></h2>
@@ -24,6 +24,7 @@ endif;
             <?php endif; ?>
             <p class="explanation"><?php echo __('Changes will be processed in the background item by item, so you should check logs for success and errors.'); ?></p>
             <?php
+            echo $this->formHidden('all', true);
             echo $this->formHidden('params', json_encode($params));
             ?>
         </fieldset>

--- a/admin/themes/default/items/batch-edit-common.php
+++ b/admin/themes/default/items/batch-edit-common.php
@@ -1,0 +1,69 @@
+<fieldset id="item-fields">
+    <h2><?php echo __('Item Metadata'); ?></h2>
+
+    <?php if ( is_allowed('Items', 'makePublic') ): ?>
+    <div class="field">
+        <label class="two columns alpha" for="metadata[public]"><?php echo __('Public?'); ?></label>
+        <div class="inputs five columns omega">
+            <?php
+            $publicOptions = array(''  => __('Select Below'),
+                                   '1' => __('Public'),
+                                   '0' => __('Not Public')
+                                   );
+            echo $this->formSelect('metadata[public]', null, array(), $publicOptions); ?>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <?php if ( is_allowed('Items', 'makeFeatured') ): ?>
+    <div class="field">
+        <label class="two columns alpha" for="metadata[featured]"><?php echo __('Featured?'); ?></label>
+        <div class="inputs five columns omega">
+            <?php
+            $featuredOptions = array(''  => __('Select Below'),
+                                     '1' => __('Featured'),
+                                     '0' => __('Not Featured')
+                                     );
+            echo $this->formSelect('metadata[featured]', null, array(), $featuredOptions); ?>
+        </div>
+    </div>
+    <?php endif; ?>
+
+    <div class="field">
+        <label class="two columns alpha" for="metadata[item_type_id]"><?php echo __('Item Type'); ?></label>
+        <div class="inputs five columns omega">
+        <?php
+        $itemTypeOptions = get_db()->getTable('ItemType')->findPairsForSelectForm();
+        $itemTypeOptions = array('' => __('Select Below')) + $itemTypeOptions;
+        echo $this->formSelect('metadata[item_type_id]', null, array(), $itemTypeOptions);
+        ?>
+            <div class="batch-edit-remove">
+                <?php echo $this->formCheckbox('removeMetadata[item_type_id]'); ?>
+                <label for="removeMetadata[item_type_id]" style="float:none;"><?php echo __('Remove?'); ?></label>
+            </div>
+        </div>
+    </div>
+
+    <div class="field">
+        <label class="two columns alpha" for="metadata[collection_id]"><?php echo __('Collection'); ?></label>
+        <div class="inputs five columns omega">
+            <?php
+            $collectionOptions = get_db()->getTable('Collection')->findPairsForSelectForm();
+            $collectionOptions = array('' => __('Select Below')) + $collectionOptions;
+            echo $this->formSelect('metadata[collection_id]', null, array(), $collectionOptions);
+            ?>
+            <div class="batch-edit-remove">
+                <?php echo $this->formCheckbox('removeMetadata[collection_id]'); ?>
+                <label class="two columns alpha" for="removeMetadata[collection_id]" style="float:none;"><?php echo __('Remove?'); ?></label>
+            </div>
+        </div>
+    </div>
+
+    <div class="field">
+        <label class="two columns alpha" for="metadata[tags]"><?php echo __('Add Tags'); ?></label>
+        <div class="inputs five columns omega">
+            <?php echo $this->formText('metadata[tags]', null, array('size' => 32)); ?>
+            <p class="explanation"><?php echo __('List of tags to add to all checked items, separated by %s.', option('tag_delimiter')); ?></p>
+        </div>
+    </div>
+</fieldset>

--- a/admin/themes/default/items/batch-edit.php
+++ b/admin/themes/default/items/batch-edit.php
@@ -13,6 +13,7 @@ endif;
 
 <form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-save')); ?>" method="post" accept-charset="utf-8">
     <section class="seven columns alpha">
+        <?php if (isset($itemIds)): ?>
         <fieldset id="item-list" class="panel">
             <h2 class="two columns alpha"><?php echo __('Items'); ?></h2>
             <div class="five columns omega">
@@ -37,12 +38,29 @@ endif;
                 <p class="explanation"><?php echo __('Changes will be applied to checked items.'); ?></p>
             </div>
         </fieldset>
-    
+        <?php else: ?>
+        <fieldset class="panel">
+            <h2><?php echo __('Search Filters'); ?></h2>
+            <?php if ($params):
+                echo item_search_filters($params); ?>
+            <p class="explanation"><?php echo __('Changes will be applied to all items matching search filters above [%d].', $totalRecords); ?></p>
+            <?php else: ?>
+            <p><?php echo __('No search filter.'); ?></p>
+            <p class="explanation"><?php echo __('Changes will be applied to all items of the base [%d].', $totalRecords); ?></p>
+            <?php endif; ?>
+            <p class="explanation"><?php echo __('Changes will be processed in the background item by item, so you should check logs for success and errors.'); ?></p>
+            <?php
+            echo $this->formHidden('editAll', true);
+	        echo $this->formHidden('params', json_encode($params));
+	        $showItemFields = false;
+	        ?>
+        </fieldset>
+        <?php endif; ?>
+
         <fieldset id="item-fields">
             <h2><?php echo __('Item Metadata'); ?></h2>
     
             <?php if ( is_allowed('Items', 'makePublic') ): ?>
-        
             <div class="field">
                 <label class="two columns alpha" for="metadata[public]"><?php echo __('Public?'); ?></label>
                 <div class="inputs five columns omega">
@@ -54,7 +72,6 @@ endif;
                     echo $this->formSelect('metadata[public]', null, array(), $publicOptions); ?>
                 </div>
             </div>
-        
             <?php endif; ?>
     
             <?php if ( is_allowed('Items', 'makeFeatured') ): ?>

--- a/admin/themes/default/items/batch-edit.php
+++ b/admin/themes/default/items/batch-edit.php
@@ -13,7 +13,6 @@ endif;
 
 <form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-save')); ?>" method="post" accept-charset="utf-8">
     <section class="seven columns alpha">
-        <?php if (isset($itemIds)): ?>
         <fieldset id="item-list" class="panel">
             <h2 class="two columns alpha"><?php echo __('Items'); ?></h2>
             <div class="five columns omega">
@@ -33,99 +32,14 @@ endif;
                         array('no_escape' => true)));
                     release_object($item);
                 }
-                echo '<li>' . $this->formMultiCheckbox('items[]', null, array('checked' => 'checked'), $itemCheckboxes, '</li><li>') . '</li>'; ?>
+                echo '<li>' . $this->formMultiCheckbox('items[]', null, array('checked' => 'checked'), $itemCheckboxes, '</li><li>') . '</li>';
+                ?>
                 </ul>
                 <p class="explanation"><?php echo __('Changes will be applied to checked items.'); ?></p>
             </div>
         </fieldset>
-        <?php else: ?>
-        <fieldset class="panel">
-            <h2><?php echo __('Search Filters'); ?></h2>
-            <?php if ($params):
-                echo item_search_filters($params); ?>
-            <p class="explanation"><?php echo __('Changes will be applied to all items matching search filters above [%d].', $totalRecords); ?></p>
-            <?php else: ?>
-            <p><?php echo __('No search filter.'); ?></p>
-            <p class="explanation"><?php echo __('Changes will be applied to all items of the base [%d].', $totalRecords); ?></p>
-            <?php endif; ?>
-            <p class="explanation"><?php echo __('Changes will be processed in the background item by item, so you should check logs for success and errors.'); ?></p>
-            <?php
-            echo $this->formHidden('editAll', true);
-	        echo $this->formHidden('params', json_encode($params));
-	        $showItemFields = false;
-	        ?>
-        </fieldset>
-        <?php endif; ?>
 
-        <fieldset id="item-fields">
-            <h2><?php echo __('Item Metadata'); ?></h2>
-    
-            <?php if ( is_allowed('Items', 'makePublic') ): ?>
-            <div class="field">
-                <label class="two columns alpha" for="metadata[public]"><?php echo __('Public?'); ?></label>
-                <div class="inputs five columns omega">
-                    <?php
-                    $publicOptions = array(''  => __('Select Below'),
-                                           '1' => __('Public'),
-                                           '0' => __('Not Public')
-                                           );
-                    echo $this->formSelect('metadata[public]', null, array(), $publicOptions); ?>
-                </div>
-            </div>
-            <?php endif; ?>
-    
-            <?php if ( is_allowed('Items', 'makeFeatured') ): ?>
-            <div class="field">
-                <label class="two columns alpha" for="metadata[featured]"><?php echo __('Featured?'); ?></label>
-                <div class="inputs five columns omega">
-                    <?php
-                    $featuredOptions = array(''  => __('Select Below'),
-                                             '1' => __('Featured'),
-                                             '0' => __('Not Featured')
-                                             );
-                    echo $this->formSelect('metadata[featured]', null, array(), $featuredOptions); ?>
-                </div>
-            </div>
-            <?php endif; ?>
-            
-            <div class="field">
-                <label class="two columns alpha" for="metadata[item_type_id]"><?php echo __('Item Type'); ?></label>
-                <div class="inputs five columns omega">
-                <?php
-                $itemTypeOptions = get_db()->getTable('ItemType')->findPairsForSelectForm();
-                $itemTypeOptions = array('' => __('Select Below')) + $itemTypeOptions;
-                echo $this->formSelect('metadata[item_type_id]', null, array(), $itemTypeOptions);
-                ?>
-                    <div class="batch-edit-remove">
-                    <?php echo $this->formCheckbox('removeMetadata[item_type_id]'); ?>
-                    <label for="removeMetadata[item_type_id]" style="float:none;"><?php echo __('Remove?'); ?></label>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="field">
-                <label class="two columns alpha" for="metadata[collection_id]"><?php echo __('Collection'); ?></label>
-                <div class="inputs five columns omega">
-                    <?php
-                    $collectionOptions = get_db()->getTable('Collection')->findPairsForSelectForm();
-                    $collectionOptions = array('' => __('Select Below')) + $collectionOptions;
-                    echo $this->formSelect('metadata[collection_id]', null, array(), $collectionOptions);
-                    ?>
-                    <div class="batch-edit-remove">
-                        <?php echo $this->formCheckbox('removeMetadata[collection_id]'); ?>
-                        <label class="two columns alpha" for="removeMetadata[collection_id]" style="float:none;"><?php echo __('Remove?'); ?></label>
-                    </div>
-                </div>
-            </div>
-    
-            <div class="field">
-                <label class="two columns alpha" for="metadata[tags]"><?php echo __('Add Tags'); ?></label>
-                <div class="inputs five columns omega">
-                    <?php echo $this->formText('metadata[tags]', null, array('size' => 32)); ?>
-                    <p class="explanation"><?php echo __('List of tags to add to all checked items, separated by %s.', option('tag_delimiter')); ?></p>
-                </div>
-            </div>
-        </fieldset>
+        <?php echo common('batch-edit-common', array(), 'items'); ?>
 
         <?php fire_plugin_hook('admin_items_batch_edit_form', array('view' => $this)); ?>
     
@@ -176,6 +90,7 @@ endif;
         });
     });
 </script>
-<?php if (!$isPartial): ?>
-<?php echo foot(); ?>
-<?php endif; ?>
+<?php
+if (!$isPartial):
+    echo foot();
+endif;

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -15,27 +15,26 @@ echo item_search_filters();
     <?php echo pagination_links(); ?>
 
     <form action="<?php echo html_escape(url('items/batch-edit')); ?>" method="post" accept-charset="utf-8">
+        <?php if (is_allowed('Items', 'add')): ?>
+        <a href="<?php echo html_escape(url('items/add')); ?>" class="add button small green"><?php echo __('Add an Item'); ?></a>
+        <?php endif; ?>
+        <?php echo link_to_item_search(__('Search Items'), array('class' => 'small blue advanced-search-link button')); ?>
+        <?php echo common('quick-filters', array(), 'items'); ?>
+
         <div class="table-actions batch-edit-option">
-            <?php if (is_allowed('Items', 'add')): ?>
-            <a href="<?php echo html_escape(url('items/add')); ?>" class="add button small green"><?php echo __('Add an Item'); ?></a>
-            <?php endif; ?>
-            <?php echo link_to_item_search(__('Search Items'), array('class' => 'small blue advanced-search-link button')); ?>
-            <?php if (is_allowed('Items', 'edit')): ?>
-            <input type="submit" class="edit-items small blue batch-action button" name="submit-batch-edit" value="<?php echo __('Edit'); ?>" />
-            <?php endif; ?>
-            <?php if (is_allowed('Items', 'delete')): ?>
-            <input type="submit" class="small red batch-action button" name="submit-batch-delete" value="<?php echo __('Delete'); ?>">
-            <?php endif; ?>
             <?php if (is_allowed('Items', 'edit') || is_allowed('Items', 'delete')): ?>
-            <span title="<?php echo __('Check to batch edit or delete all the %d browsed items.', $total_results); ?>" style="margin: 0 0 20px; padding: 3px 0;">
-                <label for="batch-all"><?php echo __('All'); ?></label>
-                <input id="batch-all" type="checkbox" value="1" name="batch-all" >
-            </span>
-            <?php echo $this->formHidden('params', json_encode(Zend_Controller_Front::getInstance()->getRequest()->getParams())); ?>
+                <button class="batch-all-toggle" type="button" data-records-count="<?php echo $total_results; ?>"><?php echo __('Select all %s results', $total_results); ?></button>
+                <div class="selected"><span class="count">0</span> <?php echo __('items selected'); ?></div>
+                <input type="hidden" name="batch-all" value="1" id="batch-all" disabled>
+                <?php echo $this->formHidden('params', json_encode(Zend_Controller_Front::getInstance()->getRequest()->getParams())); ?>
+                <?php if (is_allowed('Items', 'edit')): ?>
+                <input type="submit" class="edit-items small batch-action button" name="submit-batch-edit" value="<?php echo __('Edit'); ?>" />
+                <?php endif; ?>
+                <?php if (is_allowed('Items', 'delete')): ?>
+                <input type="submit" class="small batch-action button" name="submit-batch-delete" value="<?php echo __('Delete'); ?>">
+                <?php endif; ?>
             <?php endif; ?>
         </div>
-
-        <?php echo common('quick-filters', array(), 'items'); ?>
 
         <table id="items">
         <thead>
@@ -117,24 +116,26 @@ echo item_search_filters();
             <?php endforeach; ?>
         </tbody>
         </table>
-
         <div class="table-actions batch-edit-option">
-            <?php if (is_allowed('Items', 'add')): ?>
-            <a href="<?php echo html_escape(url('items/add')); ?>" class="add button small green"><?php echo __('Add an Item'); ?></a>
-            <?php endif; ?>
-            <?php echo link_to_item_search(__('Search Items'), array('class' => 'small blue advanced-search-link button')); ?>
-            <?php if (is_allowed('Items', 'edit')): ?>
-            <input type="submit" class="small blue batch-action button" name="submit-batch-edit" value="<?php echo __('Edit'); ?>" />
-            <?php endif; ?>
-            <?php if (is_allowed('Items', 'delete')): ?>
-            <input type="submit" class="small red batch-action button" name="submit-batch-delete" value="<?php echo __('Delete'); ?>">
+            <?php if (is_allowed('Items', 'edit') || is_allowed('Items', 'delete')): ?>
+                <button class="batch-all-toggle" type="button" data-records-count="<?php echo $total_results; ?>"><?php echo __('Select all %s results', $total_results); ?></button>
+                <div class="selected"><span class="count">0</span> <?php echo __('items selected'); ?></div>
+                <?php if (is_allowed('Items', 'edit')): ?>
+                <input type="submit" class="edit-items small batch-action button" name="submit-batch-edit" value="<?php echo __('Edit'); ?>" />
+                <?php endif; ?>
+                <?php if (is_allowed('Items', 'delete')): ?>
+                <input type="submit" class="small batch-action button" name="submit-batch-delete" value="<?php echo __('Delete'); ?>">
+                <?php endif; ?>
             <?php endif; ?>
         </div>
-
-        <?php echo common('quick-filters',array(),'items'); ?>
+        <?php echo pagination_links(); ?>
+        <?php if (is_allowed('Items', 'add')): ?>
+        <a href="<?php echo html_escape(url('items/add')); ?>" class="add button small green"><?php echo __('Add an Item'); ?></a>
+        <?php endif; ?>
+        <?php echo link_to_item_search(__('Search Items'), array('class' => 'small blue advanced-search-link button')); ?>
+        <?php echo common('quick-filters', array(), 'items'); ?>
     </form>
 
-    <?php echo pagination_links(); ?>
 
     <div id="outputs">
     <span class="outputs-label"><?php echo __('Output Formats'); ?></span>

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -31,7 +31,7 @@ echo item_search_filters();
                 <label for="batch-all"><?php echo __('All'); ?></label>
                 <input id="batch-all" type="checkbox" value="1" name="batch-all" >
             </span>
-            <?php echo $this->formHidden('params', json_encode($_GET)); ?>
+            <?php echo $this->formHidden('params', json_encode(Zend_Controller_Front::getInstance()->getRequest()->getParams())); ?>
             <?php endif; ?>
         </div>
 

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -22,6 +22,7 @@ echo item_search_filters();
             <?php echo link_to_item_search(__('Search Items'), array('class' => 'small blue advanced-search-link button')); ?>
             <?php if (is_allowed('Items', 'edit')): ?>
             <input type="submit" class="edit-items small blue batch-action button" name="submit-batch-edit" value="<?php echo __('Edit'); ?>" />
+            <a href="<?php echo html_escape(url('items/batch-edit-all', $_GET)); ?>" class="edit-items small blue batch-action button"><?php echo __('Edit All'); ?></a>
             <?php endif; ?>
             <?php if (is_allowed('Items', 'delete')): ?>
             <input type="submit" class="small red batch-action button" name="submit-batch-delete" value="<?php echo __('Delete'); ?>">

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -22,10 +22,16 @@ echo item_search_filters();
             <?php echo link_to_item_search(__('Search Items'), array('class' => 'small blue advanced-search-link button')); ?>
             <?php if (is_allowed('Items', 'edit')): ?>
             <input type="submit" class="edit-items small blue batch-action button" name="submit-batch-edit" value="<?php echo __('Edit'); ?>" />
-            <a href="<?php echo html_escape(url('items/batch-edit-all', $_GET)); ?>" class="edit-items small blue batch-action button"><?php echo __('Edit All'); ?></a>
             <?php endif; ?>
             <?php if (is_allowed('Items', 'delete')): ?>
             <input type="submit" class="small red batch-action button" name="submit-batch-delete" value="<?php echo __('Delete'); ?>">
+            <?php endif; ?>
+            <?php if (is_allowed('Items', 'edit') || is_allowed('Items', 'delete')): ?>
+            <span title="<?php echo __('Check to batch edit or delete all the %d browsed items.', $total_results); ?>" style="margin: 0 0 20px; padding: 3px 0;">
+                <label for="batch-all"><?php echo __('All'); ?></label>
+                <input id="batch-all" type="checkbox" value="1" name="batch-all" >
+            </span>
+            <?php echo $this->formHidden('params', json_encode($_GET)); ?>
             <?php endif; ?>
         </div>
 
@@ -42,7 +48,7 @@ echo item_search_filters();
                 $browseHeadings[__('Creator')] = 'Dublin Core,Creator';
                 $browseHeadings[__('Type')] = null;
                 $browseHeadings[__('Date Added')] = 'added';
-                echo browse_sort_links($browseHeadings, array('link_tag' => 'th scope="col"', 'list_tag' => '')); 
+                echo browse_sort_links($browseHeadings, array('link_tag' => 'th scope="col"', 'list_tag' => ''));
                 ?>
             </tr>
         </thead>
@@ -124,7 +130,7 @@ echo item_search_filters();
             <input type="submit" class="small red batch-action button" name="submit-batch-delete" value="<?php echo __('Delete'); ?>">
             <?php endif; ?>
         </div>
-        
+
         <?php echo common('quick-filters',array(),'items'); ?>
     </form>
 

--- a/admin/themes/default/javascripts/items-browse.js
+++ b/admin/themes/default/javascripts/items-browse.js
@@ -40,12 +40,23 @@ Omeka.ItemsBrowse = {};
     Omeka.ItemsBrowse.setupBatchEdit = function () {
         var itemCheckboxes = $("table#items tbody input[type=checkbox]");
         var globalCheckbox = $('th.batch-edit-heading').html('<input type="checkbox">').find('input');
-        var batchEditSubmit = $('.batch-edit-option input');
+        var batchEditSubmit = $('.batch-edit-option input[type=submit]');
+        var batchAllCheckbox = $('#batch-all');
+
         /**
          * Disable the batch submit button first, will be enabled once item
          * checkboxes are checked.
          */
         batchEditSubmit.prop('disabled', true);
+
+        /**
+         * Disable all the itemCheckboxes if the batchAllCheckbox is checked.
+         */
+        batchAllCheckbox.change(function() {
+            globalCheckbox.prop('disabled', this.checked);
+            itemCheckboxes.prop('disabled', this.checked);
+            checkBatchEditSubmitButton();
+        });
 
         /**
          * Check all the itemCheckboxes if the globalCheckbox is checked.
@@ -68,17 +79,19 @@ Omeka.ItemsBrowse = {};
 
         /**
          * Check whether the batchEditSubmit button should be enabled.
-         * If any of the itemCheckboxes is checked, the batchEditSubmit button
-         * is enabled.
+         * If any of the itemCheckboxes or the batchAllCheckbox is checked, the
+         * batchEditSubmit button is enabled.
          */
         function checkBatchEditSubmitButton() {
-            var checked = false;
-            itemCheckboxes.each(function() {
-                if (this.checked) {
-                    checked = true;
-                    return false;
-                }
-            });
+            var checked = batchAllCheckbox.prop('checked');
+            if (!checked) {
+                itemCheckboxes.each(function() {
+                    if (this.checked) {
+                        checked = true;
+                        return false;
+                    }
+                });
+            }
 
             batchEditSubmit.prop('disabled', !checked);
         }

--- a/admin/themes/default/javascripts/items-browse.js
+++ b/admin/themes/default/javascripts/items-browse.js
@@ -41,7 +41,9 @@ Omeka.ItemsBrowse = {};
         var itemCheckboxes = $("table#items tbody input[type=checkbox]");
         var globalCheckbox = $('th.batch-edit-heading').html('<input type="checkbox">').find('input');
         var batchEditSubmit = $('.batch-edit-option input[type=submit]');
-        var batchAllCheckbox = $('#batch-all');
+        var batchAllButton = $('.batch-all-toggle');
+        var batchAllInput = $('#batch-all');
+        var selectedCounter = $('.selected .count');
 
         /**
          * Disable the batch submit button first, will be enabled once item
@@ -50,11 +52,21 @@ Omeka.ItemsBrowse = {};
         batchEditSubmit.prop('disabled', true);
 
         /**
-         * Disable all the itemCheckboxes if the batchAllCheckbox is checked.
+         * Disable all the itemCheckboxes if the batchAllButton is checked.
          */
-        batchAllCheckbox.change(function() {
-            globalCheckbox.prop('disabled', this.checked);
-            itemCheckboxes.prop('disabled', this.checked);
+        batchAllButton.click(function() {
+            batchAllButton.toggleClass('active');
+            if (batchAllButton.hasClass('active')) {
+                batchAllInput.removeAttr('disabled');
+                selectedCounter.text($(this).data('records-count'));
+                globalCheckbox.prop('disabled', 'disabled');
+                itemCheckboxes.prop('disabled', 'disabled');
+            } else  {
+                batchAllInput.prop('disabled', 'disabled');
+                selectedCounter.text($("table#items tbody input[type=checkbox]:checked").length);
+                globalCheckbox.removeAttr('disabled');
+                itemCheckboxes.removeAttr('disabled');
+            }
             checkBatchEditSubmitButton();
         });
 
@@ -63,6 +75,7 @@ Omeka.ItemsBrowse = {};
          */
         globalCheckbox.change(function() {
             itemCheckboxes.prop('checked', !!this.checked);
+            selectedCounter.text($("table#items tbody input[type=checkbox]:checked").length);
             checkBatchEditSubmitButton();
         });
 
@@ -74,16 +87,17 @@ Omeka.ItemsBrowse = {};
             if (!this.checked) {
                 globalCheckbox.prop('checked', false);
             }
+            selectedCounter.text($("table#items tbody input[type=checkbox]:checked").length);
             checkBatchEditSubmitButton();
         });
 
         /**
          * Check whether the batchEditSubmit button should be enabled.
-         * If any of the itemCheckboxes or the batchAllCheckbox is checked, the
+         * If any of the itemCheckboxes or the batchAllButton is checked, the
          * batchEditSubmit button is enabled.
          */
         function checkBatchEditSubmitButton() {
-            var checked = batchAllCheckbox.prop('checked');
+            var checked = batchAllButton.hasClass('active');
             if (!checked) {
                 itemCheckboxes.each(function() {
                     if (this.checked) {

--- a/application/controllers/ItemsController.php
+++ b/application/controllers/ItemsController.php
@@ -286,6 +286,10 @@ class ItemsController extends Omeka_Controller_AbstractActionController
             throw new Omeka_Controller_Exception_403;
         }
 
+        if ($this->_getParam('all')) {
+            return $this->_batchEditAllSave();
+        }
+
         $itemIds = $this->_getParam('items');
         if ($itemIds) {
             $metadata = $this->_getParam('metadata');
@@ -380,14 +384,8 @@ class ItemsController extends Omeka_Controller_AbstractActionController
      *
      * @return void
      */
-    public function batchEditAllSaveAction()
+    protected function _batchEditAllSave()
     {
-        $hashParam = $this->_getParam('batch_edit_hash');
-        $hash = new Zend_Form_Element_Hash('batch_edit_hash');
-        if (!$hash->isValid($hashParam)) {
-            throw new Omeka_Controller_Exception_403;
-        }
-
         // Get the record ids filtered to Omeka_Db_Table::applySearchFilters().
         $params = json_decode($this->_getParam('params'), true) ?: array();
         $totalRecords = $this->_helper->db->count($params);

--- a/application/controllers/ItemsController.php
+++ b/application/controllers/ItemsController.php
@@ -446,6 +446,6 @@ class ItemsController extends Omeka_Controller_AbstractActionController
             $this->_helper->flashMessenger(__('No item to batch edit.'), 'error');
         }
 
-        $this->_helper->redirector('browse', 'items', null, $params);
+        $this->_helper->redirector('browse', 'items');
     }
 }

--- a/application/controllers/ItemsController.php
+++ b/application/controllers/ItemsController.php
@@ -296,8 +296,6 @@ class ItemsController extends Omeka_Controller_AbstractActionController
             $select = $this->_helper->db
                 ->getSelectForFindBy($params)
                 ->reset(Zend_Db_Select::COLUMNS)
-                ->reset(Zend_Db_Select::LIMIT_COUNT)
-                ->reset(Zend_Db_Select::LIMIT_OFFSET)
                 ->columns(array("$alias.id"));
             $itemIds = get_db()->fetchCol($select);
         } else {

--- a/application/models/Job/ItemBatchEdit.php
+++ b/application/models/Job/ItemBatchEdit.php
@@ -20,6 +20,14 @@ class Job_ItemBatchEdit extends Omeka_Job_AbstractJob
         $delete = $this->_options['delete'];
         $metadata = $this->_options['metadata'];
         $custom = $this->_options['custom'];
+        $editAll = $this->_options['editAll'];
+
+        if ($editAll) {
+            foreach ($itemIds as $id) {
+                $this->_performItem($id, $delete, $metadata, $custom);
+            }
+            return;
+        }
 
         foreach ($itemIds as $id) {
             $item = $this->_getItem($id);
@@ -46,5 +54,92 @@ class Job_ItemBatchEdit extends Omeka_Job_AbstractJob
             throw new RuntimeException("Item with ID={$this->_options['itemId']} does not exist");
         }
         return $item;
+    }
+
+    /**
+     * Check if the item can be processed, then process it if possible.
+     *
+     * @param integer $itemId
+     * @param boolean $delete
+     * @param array $metadata
+     * @param array $custom
+     * @return boolean
+     */
+    protected function _performItem($itemId, $delete, $metadata, $custom)
+    {
+        $item = $this->_db->getTable('Item')->find($itemId);
+        if (!$item) {
+            $message = __('Item does not exist: it may have been deleted before processing.');
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+
+        $message = null;
+
+        /*
+        // TODO Check rights of the user to process each item in background.
+        // Check rights via acl.
+        $aclHelper = get_acl();
+
+        if ($delete && !$aclHelper->isAllowed('delete', $item)) {
+            $message = __('User is not allowed to delete this item.');
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+
+        // Check to see if anything but 'tag'.
+        if ($metadata && array_diff_key($metadata, array('tags' => '')) && !$aclHelper->isAllowed('edit', $item)) {
+            $message = __('User is not allowed to edit this item.');
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+
+        if ($metadata && array_key_exists('tags', $metadata) && !$aclHelper->isAllowed('tag', $item)) {
+            $message = __('User is not allowed to tag this item.');
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+        */
+
+        // Check errors set by plugins filters.
+        $message = apply_filters(
+            'items_batch_edit_error',
+            $message,
+            array(
+                'item_ids' => array($itemId),
+                'metadata' => $metadata,
+                'custom' => $custom,
+            )
+        );
+        if ($message) {
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+
+        // No error, so process the edition.
+        if ($delete == '1') {
+            $item->delete();
+        } else {
+            foreach ($metadata as $key => $value) {
+                if ($value === '') {
+                    unset($metadata[$key]);
+                }
+            }
+            try {
+                update_item($item, $metadata);
+                fire_plugin_hook('items_batch_edit_custom',
+                    array('item' => $item, 'custom' => $custom));
+            } catch (Exception $e) {
+                $message = __('An error occured when the item was updated: %s', $e->getMessage());
+                _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+                return false;
+            }
+        }
+
+        release_object($item);
+
+        $message = __('The item was successfully batch-edited.');
+        _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::INFO);
+        return true;
     }
 }

--- a/application/models/Job/ItemBatchEdit.php
+++ b/application/models/Job/ItemBatchEdit.php
@@ -20,14 +20,6 @@ class Job_ItemBatchEdit extends Omeka_Job_AbstractJob
         $delete = $this->_options['delete'];
         $metadata = $this->_options['metadata'];
         $custom = $this->_options['custom'];
-        $editAll = $this->_options['editAll'];
-
-        if ($editAll) {
-            foreach ($itemIds as $id) {
-                $this->_performItem($id, $delete, $metadata, $custom);
-            }
-            return;
-        }
 
         foreach ($itemIds as $id) {
             $item = $this->_getItem($id);
@@ -54,92 +46,5 @@ class Job_ItemBatchEdit extends Omeka_Job_AbstractJob
             throw new RuntimeException("Item with ID={$this->_options['itemId']} does not exist");
         }
         return $item;
-    }
-
-    /**
-     * Check if the item can be processed, then process it if possible.
-     *
-     * @param integer $itemId
-     * @param boolean $delete
-     * @param array $metadata
-     * @param array $custom
-     * @return boolean
-     */
-    protected function _performItem($itemId, $delete, $metadata, $custom)
-    {
-        $item = $this->_db->getTable('Item')->find($itemId);
-        if (!$item) {
-            $message = __('Item does not exist: it may have been deleted before processing.');
-            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
-            return false;
-        }
-
-        $message = null;
-
-        /*
-        // TODO Check rights of the user to process each item in background.
-        // Check rights via acl.
-        $aclHelper = get_acl();
-
-        if ($delete && !$aclHelper->isAllowed('delete', $item)) {
-            $message = __('User is not allowed to delete this item.');
-            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
-            return false;
-        }
-
-        // Check to see if anything but 'tag'.
-        if ($metadata && array_diff_key($metadata, array('tags' => '')) && !$aclHelper->isAllowed('edit', $item)) {
-            $message = __('User is not allowed to edit this item.');
-            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
-            return false;
-        }
-
-        if ($metadata && array_key_exists('tags', $metadata) && !$aclHelper->isAllowed('tag', $item)) {
-            $message = __('User is not allowed to tag this item.');
-            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
-            return false;
-        }
-        */
-
-        // Check errors set by plugins filters.
-        $message = apply_filters(
-            'items_batch_edit_error',
-            $message,
-            array(
-                'item_ids' => array($itemId),
-                'metadata' => $metadata,
-                'custom' => $custom,
-            )
-        );
-        if ($message) {
-            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
-            return false;
-        }
-
-        // No error, so process the edition.
-        if ($delete == '1') {
-            $item->delete();
-        } else {
-            foreach ($metadata as $key => $value) {
-                if ($value === '') {
-                    unset($metadata[$key]);
-                }
-            }
-            try {
-                update_item($item, $metadata);
-                fire_plugin_hook('items_batch_edit_custom',
-                    array('item' => $item, 'custom' => $custom));
-            } catch (Exception $e) {
-                $message = __('An error occured when the item was updated: %s', $e->getMessage());
-                _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
-                return false;
-            }
-        }
-
-        release_object($item);
-
-        $message = __('The item was successfully batch-edited.');
-        _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::INFO);
-        return true;
     }
 }

--- a/application/models/Job/ItemBatchEditAll.php
+++ b/application/models/Job/ItemBatchEditAll.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Omeka
+ *
+ * @copyright Copyright 2007-2012 Roy Rosenzweig Center for History and New Media
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GNU GPLv3
+ */
+
+/**
+ * @package Omeka\Job
+ */
+class Job_ItemBatchEditAll extends Omeka_Job_AbstractJob
+{
+
+    protected $_table;
+    protected $_aclHelper;
+
+    public function perform()
+    {
+        // Get the record ids filtered to Omeka_Db_Table::applySearchFilters().
+        $params = $this->_options['params'];
+
+        $this->_table = $this->_db->getTable('Item');
+        $alias = $this->_table->getTableAlias();
+        $select = $this->_table
+            ->getSelectForFindBy($params)
+            ->reset(Zend_Db_Select::COLUMNS)
+            ->columns(array("$alias.id"));
+        $itemIds = get_db()->fetchCol($select);
+        if (!$itemIds) {
+            return;
+        }
+
+        $this->_aclHelper = get_acl();
+
+        foreach ($itemIds as $id) {
+            $this->_performItem($id);
+        }
+    }
+
+    /**
+     * Check if the item can be processed, then process it if possible.
+     *
+     * @param integer $itemId
+     * @return boolean
+     */
+    protected function _performItem($itemId)
+    {
+        $item = $this->_table->find($itemId);
+        if (!$item) {
+            $message = __('Item does not exist: it may have been deleted before processing.');
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+
+        $delete = $this->_options['delete'];
+        $metadata = $this->_options['metadata'];
+        $custom = $this->_options['custom'];
+
+        $message = null;
+
+        /*
+        // TODO Check rights of the user to process each item in background.
+        // Check rights via acl.
+        $aclHelper = $this->_aclHelper;
+
+        if ($delete && !$aclHelper->isAllowed('delete', $item)) {
+            $message = __('User is not allowed to delete this item.');
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+
+        // Check to see if anything but 'tag'.
+        if ($metadata && array_diff_key($metadata, array('tags' => '')) && !$aclHelper->isAllowed('edit', $item)) {
+            $message = __('User is not allowed to edit this item.');
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+
+        if ($metadata && array_key_exists('tags', $metadata) && !$aclHelper->isAllowed('tag', $item)) {
+            $message = __('User is not allowed to tag this item.');
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+        */
+
+        // Check errors set by plugins filters.
+        $message = apply_filters(
+            'items_batch_edit_error',
+            $message,
+            array(
+                'item_ids' => array($itemId),
+                'metadata' => $metadata,
+                'custom' => $custom,
+            )
+        );
+        if ($message) {
+            _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+            return false;
+        }
+
+        // No error, so process the edition.
+        if ($delete == '1') {
+            $item->delete();
+        } else {
+            foreach ($metadata as $key => $value) {
+                if ($value === '') {
+                    unset($metadata[$key]);
+                }
+            }
+            try {
+                update_item($item, $metadata);
+                fire_plugin_hook('items_batch_edit_custom',
+                    array('item' => $item, 'custom' => $custom));
+            } catch (Exception $e) {
+                $message = __('An error occured when the item was updated: %s', $e->getMessage());
+                _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
+                return false;
+            }
+        }
+
+        release_object($item);
+
+        $message = __('The item was successfully batch-edited.');
+        _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::INFO);
+        return true;
+    }
+}

--- a/application/models/Job/ItemBatchEditAll.php
+++ b/application/models/Job/ItemBatchEditAll.php
@@ -31,7 +31,12 @@ class Job_ItemBatchEditAll extends Omeka_Job_AbstractJob
             return;
         }
 
-        $this->_aclHelper = get_acl();
+        // Prepare the background acl to check rights of the user for each item.
+        // $this->_aclHelper = get_acl();
+        $acl = Zend_Registry::get('bootstrap')->bootstrap('Acl')->acl;
+        $aclChecker = new Omeka_Controller_Action_Helper_Acl($acl, $this->_user);
+        Zend_Controller_Action_HelperBroker::addHelper($aclChecker);
+        $this->_aclHelper = Zend_Controller_Action_HelperBroker::getStaticHelper('Acl');
 
         foreach ($itemIds as $id) {
             $this->_performItem($id);
@@ -59,8 +64,6 @@ class Job_ItemBatchEditAll extends Omeka_Job_AbstractJob
 
         $message = null;
 
-        /*
-        // TODO Check rights of the user to process each item in background.
         // Check rights via acl.
         $aclHelper = $this->_aclHelper;
 
@@ -82,7 +85,6 @@ class Job_ItemBatchEditAll extends Omeka_Job_AbstractJob
             _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
             return false;
         }
-        */
 
         // Check errors set by plugins filters.
         $message = apply_filters(

--- a/application/models/Job/ItemBatchEditAll.php
+++ b/application/models/Job/ItemBatchEditAll.php
@@ -102,6 +102,7 @@ class Job_ItemBatchEditAll extends Omeka_Job_AbstractJob
         // No error, so process the edition.
         if ($delete == '1') {
             $item->delete();
+            $message = __('The item was successfully deleted.');
         } else {
             foreach ($metadata as $key => $value) {
                 if ($value === '') {
@@ -117,11 +118,12 @@ class Job_ItemBatchEditAll extends Omeka_Job_AbstractJob
                 _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::ERR);
                 return false;
             }
+
+            $message = __('The item was successfully batch-edited.');
         }
 
         release_object($item);
 
-        $message = __('The item was successfully batch-edited.');
         _log(__('Batch Edit Item #%d: %s', $itemId, $message), Zend_Log::INFO);
         return true;
     }

--- a/application/models/Job/ItemBatchEditAll.php
+++ b/application/models/Job/ItemBatchEditAll.php
@@ -17,9 +17,15 @@ class Job_ItemBatchEditAll extends Omeka_Job_AbstractJob
 
     public function perform()
     {
+        // Prepare the background acl to check rights of the user for each item.
+        // $this->_aclHelper = get_acl();
+        $acl = Zend_Registry::get('bootstrap')->bootstrap('Acl')->acl;
+        $aclChecker = new Omeka_Controller_Action_Helper_Acl($acl, $this->_user);
+        Zend_Controller_Action_HelperBroker::addHelper($aclChecker);
+        $this->_aclHelper = Zend_Controller_Action_HelperBroker::getStaticHelper('Acl');
+
         // Get the record ids filtered to Omeka_Db_Table::applySearchFilters().
         $params = $this->_options['params'];
-
         $this->_table = $this->_db->getTable('Item');
         $alias = $this->_table->getTableAlias();
         $select = $this->_table
@@ -30,13 +36,6 @@ class Job_ItemBatchEditAll extends Omeka_Job_AbstractJob
         if (!$itemIds) {
             return;
         }
-
-        // Prepare the background acl to check rights of the user for each item.
-        // $this->_aclHelper = get_acl();
-        $acl = Zend_Registry::get('bootstrap')->bootstrap('Acl')->acl;
-        $aclChecker = new Omeka_Controller_Action_Helper_Acl($acl, $this->_user);
-        Zend_Controller_Action_HelperBroker::addHelper($aclChecker);
-        $this->_aclHelper = Zend_Controller_Action_HelperBroker::getStaticHelper('Acl');
 
         foreach ($itemIds as $id) {
             $this->_performItem($id);


### PR DESCRIPTION
Hi,

This is a first commit to resolve the issue #689: a button is added to process all browsed items, filtered or not, via a background process. For example, this is possible to change the collection of a big number of items (see #693).

Two points may be improved: batch deletion and acl checks inside the background job.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
