### PR TITLE
Correct checkbox id for unselected record types in search menu

### DIFF
--- a/application/views/scripts/items/search-form.php
+++ b/application/views/scripts/items/search-form.php
@@ -103,7 +103,7 @@ $formAttributes['method'] = 'GET';
         </div>
     </div>
 
-    <div class="field">
+    <div id="search-by-collection" class="field">
         <?php echo $this->formLabel('collection-search', __('Search By Collection')); ?>
         <div class="inputs">
         <?php
@@ -117,7 +117,7 @@ $formAttributes['method'] = 'GET';
         </div>
     </div>
 
-    <div class="field">
+    <div id="search-by-type" class="field">
         <?php echo $this->formLabel('item-type-search', __('Search By Type')); ?>
         <div class="inputs">
         <?php
@@ -132,7 +132,7 @@ $formAttributes['method'] = 'GET';
     </div>
 
     <?php if(is_allowed('Users', 'browse')): ?>
-    <div class="field">
+    <div id="search-by-user" class="field">
     <?php
         echo $this->formLabel('user-search', __('Search By User'));?>
         <div class="inputs">
@@ -148,7 +148,7 @@ $formAttributes['method'] = 'GET';
     </div>
     <?php endif; ?>
 
-    <div class="field">
+    <div id="search-by-tags" class="field">
         <?php echo $this->formLabel('tag-search', __('Search By Tags')); ?>
         <div class="inputs">
         <?php
@@ -161,7 +161,7 @@ $formAttributes['method'] = 'GET';
 
 
     <?php if (is_allowed('Items','showNotPublic')): ?>
-    <div class="field">
+    <div id="search-by-public" class="field">
         <?php echo $this->formLabel('public', __('Public/Non-Public')); ?>
         <div class="inputs">
         <?php
@@ -179,7 +179,7 @@ $formAttributes['method'] = 'GET';
     </div>
     <?php endif; ?>
 
-    <div class="field">
+    <div id="search-by-featured" class="field">
         <?php echo $this->formLabel('featured', __('Featured/Non-Featured')); ?>
         <div class="inputs">
         <?php

--- a/application/views/scripts/search/search-form.php
+++ b/application/views/scripts/search/search-form.php
@@ -10,7 +10,7 @@
         <fieldset id="record-types">
             <legend><?php echo __('Search only these record types:'); ?></legend>
             <?php foreach ($record_types as $key => $value): ?>
-            <?php echo $this->formCheckbox('record_types[]', $key, in_array($key, $filters['record_types']) ? array('checked' => true, 'id' => 'record_types-' . $key) : null); ?> <?php echo $this->formLabel('record_types-' . $key, $value);?><br>
+            <?php echo $this->formCheckbox('record_types[]', $key, array('checked' => in_array($key, $filters['record_types']), 'id' => 'record_types-' . $key)); ?> <?php echo $this->formLabel('record_types-' . $key, $value);?><br>
             <?php endforeach; ?>
         </fieldset>
         <?php elseif (is_admin_theme()): ?>


### PR DESCRIPTION
Uncheck any of the record types in the header search menu, and
do a search. The record types which were unselected are now generated
with id="record_types" instead of id="record_types-File" for example,
and the corresponding label does nothing.