### PR TITLE
Correct checkbox id for unselected record types in search menu

### DIFF
--- a/application/views/scripts/search/search-form.php
+++ b/application/views/scripts/search/search-form.php
@@ -10,7 +10,7 @@
         <fieldset id="record-types">
             <legend><?php echo __('Search only these record types:'); ?></legend>
             <?php foreach ($record_types as $key => $value): ?>
-            <?php echo $this->formCheckbox('record_types[]', $key, in_array($key, $filters['record_types']) ? array('checked' => true, 'id' => 'record_types-' . $key) : null); ?> <?php echo $this->formLabel('record_types-' . $key, $value);?><br>
+            <?php echo $this->formCheckbox('record_types[]', $key, array('checked' => in_array($key, $filters['record_types']), 'id' => 'record_types-' . $key)); ?> <?php echo $this->formLabel('record_types-' . $key, $value);?><br>
             <?php endforeach; ?>
         </fieldset>
         <?php elseif (is_admin_theme()): ?>


### PR DESCRIPTION
Uncheck any of the record types in the header search menu, and
do a search. The record types which were unselected are now generated
with id="record_types" instead of id="record_types-File" for example,
and the corresponding label does nothing.