### PR TITLE
Use HTML5 datalist to autosuggest searchable tags

### DIFF
--- a/application/views/scripts/items/search-form.php
+++ b/application/views/scripts/items/search-form.php
@@ -33,6 +33,19 @@ $formAttributes['method'] = 'GET';
             $search = array(array('field'=>'','type'=>'','value'=>''));
         }
 
+function get_tags_datalist($id)
+{
+  $s = '<datalist id="'.$id.'">';
+  foreach (get_records('Tag', array('sort_field' => 'name'), 500) as $tagi) {
+    if ($tagi->tagCount > 0) {
+      $ename = html_escape($tagi->name);
+      $s .= '<option value="'.$ename.'" label="'.$ename.'">';
+    }
+  }
+  $s .= '</datalist>';
+  return $s;
+}
+
         //Here is where we actually build the search form
         foreach ($search as $i => $rows): ?>
             <div class="search-entry">
@@ -153,10 +166,10 @@ $formAttributes['method'] = 'GET';
         <div class="inputs">
         <?php
             echo $this->formText('tags', @$_REQUEST['tags'],
-                array('size' => '40', 'id' => 'tag-search')
+                array('size' => '40', 'id' => 'tag-search', 'list' => 'searchable-tags')
             );
         ?>
-        </div>
+        </div><?php echo get_tags_datalist('searchable-tags'); ?>
     </div>
 
 


### PR DESCRIPTION
The tag search input in advanced search form is pretty useless
as-is; users have no easy way to know what tags are available
(without looking in the tag cloud).  Use the HTML5 datalist
element to allow the input autosuggest a tag.

This is perhaps not the best way to generate the datalist...