### PR TITLE
Wrong SQL for COUNT() when paginating item-tags.

### DIFF
--- a/application/models/Table/Tag.php
+++ b/application/models/Table/Tag.php
@@ -148,7 +148,7 @@ class Table_Tag extends Omeka_Db_Table
         }
 
         if (!(array_key_exists('include_zero', $params) && $params['include_zero'])) {
-            $select->having('COUNT(records_tags.id) > 0');
+            $select->where('records_tags.id IS NOT NULL');
         }
         $select->group("tags.id");
     }


### PR DESCRIPTION
When trying to browse/paginate item tags, the number of total results is wrong.

SQL looks like this:
```sql
SELECT COUNT(DISTINCT(tags.id)) FROM `tags` AS `tags` 
LEFT JOIN `records_tags` AS `records_tags` ON records_tags.tag_id = tags.id AND records_tags.record_type = 'Item' 
LEFT JOIN `items` AS `items` ON items.id = records_tags.record_id 
HAVING (COUNT(records_tags.id) > 0)
```

This query will return all tags in system, as long as you have at least one of the tags related to Item record.
