### PR TITLE
Update Zend Framework from version 1.12.18 to 1.12.19

### DIFF
--- a/application/libraries/Zend/Db/Select.php
+++ b/application/libraries/Zend/Db/Select.php
@@ -81,7 +81,9 @@ class Zend_Db_Select
     const SQL_ASC        = 'ASC';
     const SQL_DESC       = 'DESC';
 
-    const REGEX_COLUMN_EXPR = '/^([\w]*\s*\(([^\(\)]|(?1))*\))$/';
+    const REGEX_COLUMN_EXPR       = '/^([\w]*\s*\(([^\(\)]|(?1))*\))$/';
+    const REGEX_COLUMN_EXPR_ORDER = '/^([\w]+\s*\(([^\(\)]|(?1))*\))$/';
+    const REGEX_COLUMN_EXPR_GROUP = '/^([\w]+\s*\(([^\(\)]|(?1))*\))$/';
 
     /**
      * Bind variables for query
@@ -511,7 +513,7 @@ class Zend_Db_Select
         }
 
         foreach ($spec as $val) {
-            if (preg_match(self::REGEX_COLUMN_EXPR, (string) $val)) {
+            if (preg_match(self::REGEX_COLUMN_EXPR_GROUP, (string) $val)) {
                 $val = new Zend_Db_Expr($val);
             }
             $this->_parts[self::GROUP][] = $val;
@@ -603,7 +605,7 @@ class Zend_Db_Select
                     $val = trim($matches[1]);
                     $direction = $matches[2];
                 }
-                if (preg_match(self::REGEX_COLUMN_EXPR, (string) $val)) {
+                if (preg_match(self::REGEX_COLUMN_EXPR_ORDER, (string) $val)) {
                     $val = new Zend_Db_Expr($val);
                 }
                 $this->_parts[self::ORDER][] = array($val, $direction);

--- a/application/libraries/Zend/Version.php
+++ b/application/libraries/Zend/Version.php
@@ -32,7 +32,7 @@ final class Zend_Version
     /**
      * Zend Framework version identification - see compareVersion()
      */
-    const VERSION = '1.12.18';
+    const VERSION = '1.12.19';
 
     /**
      * The latest stable version Zend Framework available


### PR DESCRIPTION
According to Zend, version 1.12.19:
"This release includes a single security patch, reported as ZF2016-02, for SQL injection vulnerabilities in the Zend_Db_Select::order() and Zend_Db_Select::group() methods. If you use these, we recommend updating immedaitely."

For more information visit here https://framework.zend.com/blog/2016-07-13-ZF-1.12.19-Released.html

I updated the parts of the ZendFrame that is used in Omeka.