### PR TITLE
Disabled HTML filtering in TinyMCE editor

### DIFF
--- a/admin/themes/default/javascripts/globals.js
+++ b/admin/themes/default/javascripts/globals.js
@@ -27,7 +27,8 @@ if (!Omeka) {
             media_strict: false,
             width: "100%",
             autoresize_max_height: 500,
-            entities: "160,nbsp,173,shy,8194,ensp,8195,emsp,8201,thinsp,8204,zwnj,8205,zwj,8206,lrm,8207,rlm"
+            entities: "160,nbsp,173,shy,8194,ensp,8195,emsp,8201,thinsp,8204,zwnj,8205,zwj,8206,lrm,8207,rlm",
+            verify_html: false
         };
 
         tinyMCE.init($.extend(initParams, params));
@@ -72,7 +73,7 @@ if (!Omeka) {
             });
         }
     };
-    
+
     Omeka.stickyNav = function() {
         var $nav    = $("#content-nav"),
             $window = $(window);
@@ -87,7 +88,7 @@ if (!Omeka) {
             }
         });
     };
-    
+
 
     Omeka.showAdvancedForm = function () {
         var advancedForm = $('#advanced-form');


### PR DESCRIPTION
Hello, 

It seems problematic to me to have HTML filtering happening at two places in the codebase (TinyMCE + HTML Purifier). 

I believe it creates a confusing experience for the user because there is an option in the security settings to enable / disable HTML filtering, but it seems like it’s not respected because TinyMCE is doing its own filtering. 

Besides, TinyMCE isn’t an awesome solution on its own for HTML filtering, since it’s client side and can be easily bypassed.

I think the best solution would be to rely on HTML Purifier alone. 

What do you think? 

-Adam
