### PR TITLE
Added an option to select the admin theme in Appearance/Settings.

### DIFF
--- a/application/forms/AppearanceSettings.php
+++ b/application/forms/AppearanceSettings.php
@@ -63,6 +63,17 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
             'class' => 'checkbox',
         ));
 
+        $adminThemes = Theme::getAllAdminThemes();
+        if (count($adminThemes) > 1 && is_allowed('Themes', 'edit')) {
+            foreach ($adminThemes as &$theme) {
+                $theme = $theme->title;
+            }
+            $this->addElement('select', Theme::ADMIN_THEME_OPTION, array(
+                'label' => __('Admin Theme'),
+                'multiOptions' => $adminThemes,
+            ));
+        }
+
         $this->addElement('hash', 'appearance_csrf', array(
             'timeout' => 3600
         ));
@@ -83,6 +94,14 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
             'display-settings', array('legend' => __('Display Settings'))
         );
 
+        if (count($adminThemes) > 1 && is_allowed('Themes', 'edit')) {
+            $this->addDisplayGroup(
+                array(
+                    Theme::ADMIN_THEME_OPTION,
+                ),
+                'admin-themes', array('legend' => __('Admin Themes'))
+            );
+        }
     }
 
 }

--- a/application/models/Theme.php
+++ b/application/models/Theme.php
@@ -256,6 +256,32 @@ class Theme
         return $themes;
     }
 
+    /**
+     * Retrieve all admin themes
+     *
+     * @todo Merge with getAllThemes() or make Theme more generic.
+     * @return array An array of theme objects
+     */
+    static public function getAllAdminThemes()
+    {
+        /**
+         * Create an array of themes, with the directory paths
+         * theme.ini files and images paths if they are present
+         */
+        $themes = array();
+        $iterator = new VersionedDirectoryIterator(ADMIN_THEME_DIR);
+        $themeDirs = $iterator->getValid();
+        foreach ($themeDirs as $themeName) {
+            $theme = self::getTheme($themeName);
+            $theme->path = ADMIN_THEME_DIR . '/' . $themeName;
+            $theme->setImage(self::THEME_IMAGE_FILE_NAME);
+            $theme->setIni(self::THEME_INI_FILE_NAME);
+            $theme->setConfig(self::THEME_CONFIG_FILE_NAME);
+            $themes[$themeName] = $theme;
+        }
+        ksort($themes);
+        return $themes;
+    }
 
     /**
      * Retrieve a theme.


### PR DESCRIPTION
Hi,

I added an option to select the admin theme in Appearance/Settings (the option is displayed only when there are multiple themes).

This quick patch allows to customize some pieces of the admin theme simply by a copy of it in another folder in admin/themes. 

There are some works to do to make the class Theme more generic and to use the files in the theme default as default, but this is not really needed.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management