### PR TITLE
Redirect back to theme configuration page

### DIFF
--- a/application/controllers/ThemesController.php
+++ b/application/controllers/ThemesController.php
@@ -82,7 +82,7 @@ class ThemesController extends Omeka_Controller_AbstractActionController
             if (($newOptions = $configHelper->processForm($form, $_POST, $themeOptions))) {
                 Theme::setOptions($themeName, $newOptions);
                 $this->_helper->flashMessenger(__('The theme settings were successfully saved!'), 'success');
-                $this->_helper->redirector('browse');
+                $this->_helper->redirector->gotoUrl('themes/config?name='. $themeName);
             } else {
                 $this->_helper->_flashMessenger(__('There was an error on the form. Please try again.'), 'error');
             }


### PR DESCRIPTION
I think it's more consistent and practical to stay on `config` action, when editing theme configuration. At least both _Navigation_ and _Settings_ tab under _Appearance_ works that way. 
For theme configuration users are often trying different settings and want to preview it in browser before leaving the page.
