### PR TITLE
Default support for "field IS NULL" condition

### DIFF
--- a/application/libraries/Omeka/Db/Table.php
+++ b/application/libraries/Omeka/Db/Table.php
@@ -368,7 +368,11 @@ class Omeka_Db_Table
                 if (is_array($params[$column])) {
                     $select->where("`$alias`.`$column` IN (?)", $params[$column]);
                 } else {
-                    $select->where("`$alias`.`$column` = ?", $params[$column]);
+                    if ($params[$column] === null) {
+                        $select->where("`$alias`.`$column` IS NULL");
+                    } else {
+                        $select->where("`$alias`.`$column` = ?", $params[$column]);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Problem:
```php
echo  get_db()->getTable('Item')->getSelectForFindBy(array('item_type_id' => null));
```
Expected:
```sql
SELECT items.* FROM items WHERE item_type_id IS NULL
```
Actual:
```sql
SELECT items.* FROM items WHERE item_type_id = ?
```
And then you get error, because `null` is not passed as extra parameter into prepared statement.

I know, it won't fix calls like:
```php
echo get_db()->getTable('Item')->getSelectForFindBy(array('item_type_id' => array(1, 2, null)));
``` 
Should I fix NULL in arrays as well? So it would produce SQL like: `WHERE (item_type_id IN (1,2) OR item_type_id IS NULL)`?

I'm not 100% sure if this change doesn't break it for other Omeka users calling `parent::applySearchFilters()` from their plugins, but I checked few plugins (ExhibitBuilder, SimplePages, HistoryLog)  and it's OK.