### PR TITLE
Improved the detection of common mime types for some plain text.

### DIFF
--- a/application/libraries/Omeka/File/MimeType/Detect.php
+++ b/application/libraries/Omeka/File/MimeType/Detect.php
@@ -128,6 +128,28 @@ class Omeka_File_MimeType_Detect
             $this->_mimeType = (false === $fallbackMimeType) ? 'application/octet-stream' : $fallbackMimeType;
         }
         
+        // Detect some common "plain text" via the extension. Most important
+        // ones are json and xml.
+        if ($this->_mimeType == 'text/plain') {
+            $extensions = array(
+                'css' => 'text/css',
+                'csv' => 'text/csv',
+                'htm' => 'text/html',
+                'html' => 'text/html',
+                'json' => 'application/json',
+                'marc' => 'application/marc',
+                'md' => 'text/markdown',
+                'rtf' => 'text/rtf',
+                'tsv' => 'text/tab-separated-values',
+                'xhtml' => 'application/xhtml+xml',
+                'xml' => 'text/xml',
+            );
+            $extension = strtolower(pathinfo($this->_file, PATHINFO_EXTENSION));
+            if (isset($extensions[$extension])) {
+                $this->_mimeType = $extensions[$extension];
+            }
+        }
+
         // Return the definitive MIME type.
         return $this->_mimeType;
     }

--- a/application/libraries/Omeka/File/MimeType/Detect/Strategy/MimeContentType.php
+++ b/application/libraries/Omeka/File/MimeType/Detect/Strategy/MimeContentType.php
@@ -14,11 +14,28 @@ class Omeka_File_MimeType_Detect_Strategy_MimeContentType
 {
     public function detect($file)
     {
-        if (!function_exists('mime_content_type')) {
-            // The mime_content_type has been deprecated and will be removed in 
-            // future versions of PHP.
-            return false;
+        $mimetype = mime_content_type($file);
+        // Detect some common "plain text" via the extension. Most important ones
+        // are json and xml.
+        if ($mimetype == 'text/plain') {
+            $extensions = array(
+                'css' => 'text/css',
+                'csv' => 'text/csv',
+                'htm' => 'text/html',
+                'html' => 'text/html',
+                'json' => 'application/json',
+                'marc' => 'application/marc',
+                'md' => 'text/markdown',
+                'rtf' => 'text/rtf',
+                'tsv' => 'text/tab-separated-values',
+                'xhtml' => 'application/xhtml+xml',
+                'xml' => 'text/xml',
+            );
+            $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
+            if (isset($extensions[$extension])) {
+                $mimetype = $extensions[$extension];
+            }
         }
-        return mime_content_type($file);
+        return $mimetype;
     }
 }

--- a/application/libraries/Omeka/File/MimeType/Detect/Strategy/MimeContentType.php
+++ b/application/libraries/Omeka/File/MimeType/Detect/Strategy/MimeContentType.php
@@ -14,28 +14,9 @@ class Omeka_File_MimeType_Detect_Strategy_MimeContentType
 {
     public function detect($file)
     {
-        $mimetype = mime_content_type($file);
-        // Detect some common "plain text" via the extension. Most important ones
-        // are json and xml.
-        if ($mimetype == 'text/plain') {
-            $extensions = array(
-                'css' => 'text/css',
-                'csv' => 'text/csv',
-                'htm' => 'text/html',
-                'html' => 'text/html',
-                'json' => 'application/json',
-                'marc' => 'application/marc',
-                'md' => 'text/markdown',
-                'rtf' => 'text/rtf',
-                'tsv' => 'text/tab-separated-values',
-                'xhtml' => 'application/xhtml+xml',
-                'xml' => 'text/xml',
-            );
-            $extension = strtolower(pathinfo($file, PATHINFO_EXTENSION));
-            if (isset($extensions[$extension])) {
-                $mimetype = $extensions[$extension];
-            }
+        if (!function_exists('mime_content_type')) {
+            return false;
         }
-        return $mimetype;
+        return mime_content_type($file);
     }
 }

--- a/application/views/helpers/FileMarkup.php
+++ b/application/views/helpers/FileMarkup.php
@@ -548,7 +548,7 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
         
         // Append a class name that corresponds to the MIME type.
         if ($wrapperAttributes) {
-            $mimeTypeClassName = str_ireplace('/', '-', $file->mime_type);
+            $mimeTypeClassName = str_replace('+', '-', str_replace('/', '-', $file->mime_type));
             if (array_key_exists('class', $wrapperAttributes)) {
                 $wrapperAttributes['class'] .= ' ' . $mimeTypeClassName;
             } else {


### PR DESCRIPTION
Hi,

The "text/plain" mimetype is not very useful, so this patch sets the common text/plain, in particular for json and xml files.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management
