### PR TITLE
Allow setting class to li tag in navigation menu

### DIFF
--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -2689,7 +2689,7 @@ function nav(array $navLinks, $name = null, array $args = array())
     }
 
     $menu = get_view()->navigation()->menu(new Omeka_Navigation($navLinks))
-        ->addaddPageClassToLi(!empty($args['li_class']));
+        ->addPageClassToLi(!empty($args['li_class']));
 
     if ($acl = get_acl()) {
         $menu->setRole(current_user())->setAcl($acl);

--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -2676,7 +2676,8 @@ function link_to_admin_home_page($text = null, $props = array())
  * @param array $navLinks The array of links for the navigation.
  * @param string $name Optionally, the name of a filter to pass the links
  *  through before using them.
- * @param array $args Optionally, arguments to pass to the filter
+ * @param array $args Optionally, arguments to pass to the filter. Predefined:
+ *  - 'li_class' bool - should be used provided class for <li> instead of <a> tag? By default false.
  *
  * @return Zend_View_Helper_Navigation_Menu The navigation menu object. Can
  *  generally be treated simply as a string.
@@ -2687,7 +2688,8 @@ function nav(array $navLinks, $name = null, array $args = array())
         $navLinks = apply_filters($name, $navLinks, $args);
     }
 
-    $menu = get_view()->navigation()->menu(new Omeka_Navigation($navLinks));
+    $menu = get_view()->navigation()->menu(new Omeka_Navigation($navLinks))
+        ->addaddPageClassToLi(!empty($args['li_class']));
 
     if ($acl = get_acl()) {
         $menu->setRole(current_user())->setAcl($acl);


### PR DESCRIPTION
This is small update, but very handy. 
```php
nav(['uri' => '/', 'label' => 'Home', 'class' => 'home-nav']);
```
produces
```html
<li><a href="/" class="home-nav">Home</a></li>
```
This is OK in most cases, but sometimes is very useful to set class on wrapping `<li>` instead. So my pull req enables:
```php
nav(['uri' => '/', 'label' => 'Home', 'class' => 'home-nav'], null, ['li_class' => true]);
```
which produces
```html
<li class="home-nav"><a href="/">Home</a></li>
```
