### PR TITLE
Backport unsaved warning JS from S

### DIFF
--- a/admin/themes/default/javascripts/globals.js
+++ b/admin/themes/default/javascripts/globals.js
@@ -166,6 +166,7 @@ if (!Omeka) {
             formsToCheck.each(function () {
                 var form = $(this);
                 var originalData = form.data('omekaFormOriginalData');
+                var hasFile = false;
                 if (form.data('omekaFormSubmitted')) {
                     return;
                 }
@@ -176,8 +177,16 @@ if (!Omeka) {
                     tinyMCE.triggerSave();
                 }
 
+                form.find('input[type=file]').each(function () {
+                    if (this.files.length) {
+                        hasFile = true;
+                        return false;
+                    }
+                });
+
                 if (form.data('omekaFormDirty')
                     || (originalData && originalData !== form.serialize())
+                    || hasFile
                 ) {
                     preventNav = true;
                     return false;

--- a/admin/themes/default/javascripts/globals.js
+++ b/admin/themes/default/javascripts/globals.js
@@ -28,7 +28,8 @@ if (!Omeka) {
             width: "100%",
             autoresize_max_height: 500,
             entities: "160,nbsp,173,shy,8194,ensp,8195,emsp,8201,thinsp,8204,zwnj,8205,zwj,8206,lrm,8207,rlm",
-            verify_html: false
+            verify_html: false,
+            add_unload_trigger: false
         };
 
         tinyMCE.init($.extend(initParams, params));
@@ -143,12 +144,59 @@ if (!Omeka) {
         });
     };
 
+    Omeka.warnIfUnsaved = function() {
+        var setSubmittedFlag = function () {
+            $(this).data('omekaFormSubmitted', true);
+        };
+
+        var setOriginalData = function () {
+            $(this).data('omekaFormOriginalData', $(this).serialize());
+        };
+
+        var formsToCheck = $('form[method=POST]:not(.disable-unsaved-warning)');
+        formsToCheck.on('o:form-loaded', setOriginalData);
+        formsToCheck.each(function () {
+            var form = $(this);
+            form.trigger('o:form-loaded');
+            form.submit(setSubmittedFlag);
+        });
+
+        $(window).on('beforeunload', function() {
+            var preventNav = false;
+            formsToCheck.each(function () {
+                var form = $(this);
+                var originalData = form.data('omekaFormOriginalData');
+                if (form.data('omekaFormSubmitted')) {
+                    return;
+                }
+
+                form.trigger('o:before-form-unload');
+
+                if (window.tinyMCE) {
+                    tinyMCE.triggerSave();
+                }
+
+                if (form.data('omekaFormDirty')
+                    || (originalData && originalData !== form.serialize())
+                ) {
+                    preventNav = true;
+                    return false;
+                }
+            });
+
+            if (preventNav) {
+                return 'You have unsaved changes.';
+            }
+        });
+    };
+
     Omeka.readyCallbacks = [
         [Omeka.deleteConfirm, null],
         [Omeka.saveScroll, null],
         [Omeka.stickyNav, null],
         [Omeka.showAdvancedForm, null],
         [Omeka.skipNav, null],
-        [Omeka.mediaFallback, null]
+        [Omeka.mediaFallback, null],
+        [Omeka.warnIfUnsaved, null]
     ];
 })(jQuery);

--- a/admin/themes/default/javascripts/navigation.js
+++ b/admin/themes/default/javascripts/navigation.js
@@ -15,6 +15,9 @@ Omeka.Navigation = {};
             placeholder: 'ui-sortable-highlight',
             forcePlaceholderSize: true,
             containment: 'document',
+            change: function () {
+                $('#navigation_form').data('omekaFormDirty', true);
+            }
         });
         
         $('div.sortable-item input[type="checkbox"]').click(function(e) {


### PR DESCRIPTION
As promised, the unsaved warning implementation backported from S, as an alternative to #722 and #753.

This is my preferred alternative, but I'd be interested to know if there's some downside or corner case I'm not accounting for with it.