### PR TITLE
Update search index on tag name change.

### DIFF
--- a/application/controllers/TagsController.php
+++ b/application/controllers/TagsController.php
@@ -32,7 +32,7 @@ class TagsController extends Omeka_Controller_AbstractActionController
      */
     public function browseAction()
     {
-        $params = $this->_getAllParams();
+        $params = $this->getAllParams();
         
         //Check to see whether it will be tags for exhibits or for items
         //Default is Item
@@ -93,10 +93,10 @@ class TagsController extends Omeka_Controller_AbstractActionController
         $csrf = new Omeka_Form_SessionCsrf;
         $oldTagId = $_POST['id'];
         $oldTag = $this->_helper->db->findById($oldTagId);
-        $oldName = $oldTag->name;
+        $oldName = trim($oldTag->name);
         $newName = trim($_POST['value']);
 
-        $oldTag->name = $newName;
+        $oldTag->setPostData(array('name' => $newName, 'nameChanged' => ($oldName != $newName)));
         $this->_helper->viewRenderer->setNoRender();
         if ($csrf->isValid($_POST) && $oldTag->save(false)) {
             $this->getResponse()->setBody($newName);

--- a/application/models/Job/SearchTextIndex.php
+++ b/application/models/Job/SearchTextIndex.php
@@ -16,6 +16,18 @@ class Job_SearchTextIndex extends Omeka_Job_AbstractJob
      */
     public function perform()
     {
+        // when passing specific records, do only update
+        // (works safely only with hundreds of records, because `args` column is TEXT type)
+        if (!empty($this->_options['records'])) {
+            return $this->_performUpdate($this->_options['records']);
+        }
+        // when passing custom SQL, do update on the found records
+        // (solves TEXT data type limitation when passing thousands of records to update)
+        if (!empty($this->_options['sql'])) {
+            $recordMap = $this->_getRecordMapFromSql($this->_options['sql']);
+            return $this->_performUpdate($recordMap);
+        }
+        
         // Truncate the `search_texts` table before indexing to clean out 
         // obsolete records.
         $sql = "TRUNCATE TABLE {$this->_db->SearchText}";
@@ -25,17 +37,8 @@ class Job_SearchTextIndex extends Omeka_Job_AbstractJob
             
             $recordType = is_string($key) ? $key : $value;
             
-            if (!class_exists($recordType)) {
-                // The class does not exist or cannot be found.
-                continue;
-            }
-            $record = new $recordType;
-            if (!($record instanceof Omeka_Record_AbstractRecord)) {
-                // The class is not a valid record.
-                continue;
-            }
-            if (!is_callable(array($record, 'addSearchText'))) {
-                // The record does not implement the search mixin.
+            $record = $this->_getIndexedRecordByType($recordType);
+            if (!$record) {
                 continue;
             }
             
@@ -54,9 +57,103 @@ class Job_SearchTextIndex extends Omeka_Job_AbstractJob
                             Zend_Log::ERR);
                     }
                     release_object($recordObject);
+                    // TODO/Question - what about short usleep(5000); here as well?? spends less than half of cpu
                 }
                 $pageNumber++;
             }
         }
+    }
+    /**
+     * Updates index for given record_type + record_id(s).
+     *
+     * @param mixed $recordMap Map of record types and their ids, in format:
+     * <code>
+     *  [
+     *      (string) recordType => [(int) recordId, (int) recordId, ...],
+     *      (string) recordType2 => [(int) recordId, (int) recordId, ...],
+     *      ...
+     *  ]
+     * </code>
+     * @return void
+     */
+    protected function _performUpdate($recordMap)
+    {
+        foreach (get_custom_search_record_types() as $key => $value) {
+            $recordType = is_string($key) ? $key : $value;
+    
+            if (empty($recordMap[$recordType])) {
+                continue;
+            }
+            $record = $this->_getIndexedRecordByType($recordType);
+            if (!$record) {
+                continue;
+            }
+    
+            $recordTable = $record->getTable();
+            $recordTableAlias = $recordTable->getTableAlias();
+            $pageNumber = 0;
+            $perPpage = 100;
+            // Find all record by given list of ids (paginated by 100).
+            while ($ids = array_slice($recordMap[$recordType], $pageNumber * $perPpage, $perPpage)) {
+                $recordObjects = $recordTable->fetchObjects($recordTable->getSelect()->where("$recordTableAlias.id IN (?)", $ids));
+                foreach ($recordObjects as $recordObject) {
+                    // Save the record object, which indexes its search text.
+                    try {
+                        $recordObject->save();
+                    } catch (Omeka_Validate_Exception $e) {
+                        _log($e, Zend_Log::ERR);
+                        _log(sprintf('Failed to index %s #%s',
+                                get_class($recordObject), $recordObject->id),
+                                Zend_Log::ERR);
+                    }
+                    release_object($recordObject);
+                    usleep(5000);
+                }
+                $pageNumber++;
+            }
+        }
+    }
+    /**
+     * Retrieves map of records to update from given SQL query.
+     *
+     * @param string $sql Select query that must specify `record_type` and `record_id` columns.
+     *  Example1: SELECT `record_type`, `record_id` FROM `records_tags`
+     *  Example2: SELECT 'Item' AS `record_type`, `items`.`id` AS `record_id` FROM `items`
+     * @return ArrayObject $recordMap Map of records, where key is record type and values is array of record ids.
+     *  Returns empty array if nothing found.
+     */
+    protected function _getRecordMapFromSql($sql)
+    {
+        $recordMap = new ArrayObject();
+        $records = $this->_db->fetchAll($sql);
+        foreach ($records as $record) {
+            if (isset($record['record_type'], $record['record_id'])) {
+                $recordMap[$record['record_type']][] = $record['record_id'];
+            }
+        }
+        return $recordMap;
+    }
+    /**
+     * Retrieves record that should be indexed by given record type.
+     *
+     * @param string $recordType
+     * @return null|Omeka_Record_AbstractRecord Returns null if record doesn't exist or doesn't implement search mixin.
+     */
+    protected function _getIndexedRecordByType($recordType)
+    {
+        if (!class_exists($recordType)) {
+            // The class does not exist or cannot be found.
+            return null;
+        }
+        $record = new $recordType;
+        if (!($record instanceof Omeka_Record_AbstractRecord)) {
+            // The class is not a valid record.
+            return null;
+        }
+        if (!is_callable(array($record, 'addSearchText'))) {
+            // The record does not implement the search mixin.
+            return null;
+        }
+        return $record;
     }
 }


### PR DESCRIPTION
This is solution for issue #764 
It also adds possibility to update search index (instead of always creating new from scratch). The update can be accomplished in 2 ways:
1.  using SQL (by selecting or aliasing `record_type`, `record_id` columns)
```php
Zend_Registry::get('bootstrap')->getResource('jobs')
    ->sendLongRunning('Job_SearchTextIndex', array(
        'sql' => "SELECT record_type, record_id FROM table WHERE x=y"
    ));
````
2. using array (maps record types and ids to update)
```php
Zend_Registry::get('bootstrap')->getResource('jobs')
    ->sendLongRunning('Job_SearchTextIndex', array(
        'records' => array(
            'Item' => array(1,2,3,4, ...),
            'Collection' => array(1,2,3,4, ...),
        )
    ));
````

@zerocrates I know you said it is too big update for version 2.5, but I think it's really practical to be able update the search index via core job and it doesn't feel like a dangerous update or complicated one.