### PR TITLE
Use X-Forwarded headers when deciding whether to set HTTPS 

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -49,6 +49,8 @@ define('SCRIPTS_DIR', APP_DIR . '/scripts');
 if ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true))
     || (isset($_SERVER['HTTP_SCHEME']) && $_SERVER['HTTP_SCHEME'] == 'https')
     || (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)
+    || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+    || (isset($_SERVER['HTTP_X_FORWARDED_PORT']) && $_SERVER['HTTP_X_FORWARDED_PORT'] == '443')
 ) {
     $base_root = 'https';
 } else {


### PR DESCRIPTION
Hi there,

I'm submitting this PR to fix an issue I encountered where the base URL scheme is not set properly  when SSL is offloaded/terminated at a load balancer. The issue is that instead of setting the scheme to *https* as expected, it sets the scheme to *http*.

Omeka can detect that a client has initiated an HTTPS request that was offloaded to a load balancer by checking the [X-Forwarded](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html) headers.

The solution proposed by this PR is to modify `bootstrap.php` to check the `X-Forwarded-Proto` and `X-Forwarded-Port` header values and set the scheme accordingly. 

@zerocrates Thoughts?