### PR TITLE
Wrong conditions for Tag filtering by tag type

### DIFF
--- a/application/models/Table/Tag.php
+++ b/application/models/Table/Tag.php
@@ -89,8 +89,9 @@ class Table_Tag extends Omeka_Db_Table
         $select->reset(Zend_Db_Select::FROM)
                ->from(array('tags' => $db->Tag), array())
                ->joinLeft(array('records_tags' => $db->RecordsTags),
-                    "records_tags.tag_id = tags.id AND records_tags.record_type = $recordType",
-                    array());
+                    "records_tags.tag_id = tags.id",
+                    array())
+               ->where("records_tags.record_type = $recordType");
 
         //Showing tags related to items
         if ($type == 'Item') {


### PR DESCRIPTION
The current condition produces something like:
```sql
SELECT tags.* FROM tags
LEFT JOIN records_tags ON (records_tags.tag_id = tags.id AND records_tags.record_type = 'Item')
LEFT JOIN items ON items.id = records_tags.record_id
ORDER BY tags.name ASC
```
So for everybody with sufficient privilege to *showNotPublic* Items, it's impossible to filter only tags for specific record type.