### PR TITLE
Admin tags page with pagination and search, closes #784

### DIFF
--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -2209,13 +2209,13 @@ header nav {
         box-shadow: 0px 0px 2px rgba(0,0,0,.1) inset, 1px 1px 2px rgba(0,0,0,.1);
         text-shadow: none;
     }
-    #tags-nav span.current:after {
+    #tags-nav span.current a:after {
         padding-left: 5px;
     }
-    #tags-nav span.current.asc:after {
+    #tags-nav span.current.asc a:after {
         content: '\25b2';/*&#9650;*/
     }
-    #tags-nav span.current.desc:after {
+    #tags-nav span.current.desc a:after {
         content: '\25bc';/*&#9660;*/
     }
 

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -2109,7 +2109,7 @@ header nav {
     box-shadow: 0px 0px 1px #BDD662;
 }
 
-.tag-list li .tag, .tag-list li a {
+.tag-list li .tag, .tag-list li a, .tag-list li .count {
     color: #ffffff;
     display: inline-block;
 }
@@ -2208,7 +2208,16 @@ header nav {
         -moz-box-shadow: 0px 0px 2px rgba(0,0,0,.1) inset, 1px 1px 2px rgba(0,0,0,.1);
         box-shadow: 0px 0px 2px rgba(0,0,0,.1) inset, 1px 1px 2px rgba(0,0,0,.1);
         text-shadow: none;
-        }
+    }
+    #tags-nav span.current:after {
+        padding-left: 5px;
+    }
+    #tags-nav span.current.asc:after {
+        content: '\25b2';/*&#9650;*/
+    }
+    #tags-nav span.current.desc:after {
+        content: '\25bc';/*&#9660;*/
+    }
 
 .tags div.two.columns { clear: both; }
 

--- a/application/controllers/TagsController.php
+++ b/application/controllers/TagsController.php
@@ -11,6 +11,8 @@
  */
 class TagsController extends Omeka_Controller_AbstractActionController
 {
+    protected $_browseRecordsPerPage = 100;
+
     public function init()
     {
         $this->_helper->db->setDefaultModelName('Tag');
@@ -31,35 +33,34 @@ class TagsController extends Omeka_Controller_AbstractActionController
      */
     public function browseAction()
     {
-        $params = $this->_getAllParams();
-
         //Check to see whether it will be tags for exhibits or for items
-        //Default is Item
-        if (isset($params['tagType'])) {
-            $for = $params['tagType'];
-            unset($params['tagType']);
+        //Default is All
+        if ($type = $this->getParam('type')) {
+            $browse_for = $type;
+            //Since tag type must correspond to a valid classname, this will barf an error on Injection attempts
+            if (!class_exists($browse_for)) {
+                throw new InvalidArgumentException(__('Invalid tagType given.'));
+            }
+            // for specific record_type we want only tags with at least 1 relation
+            $this->setParam('include_zero', 0);
         } else {
-            $for = 'Item';
-        }
-        //Since tagType must correspond to a valid classname, this will barf an error on Injection attempts
-        if (!class_exists($for)) {
-            throw new InvalidArgumentException(__('Invalid tagType given.'));
-        }
-
-        if ($record = $this->_getParam('record')) {
-            $filter['record'] = $record;
+            $browse_for = 'All';
+            $this->setParam('type', null);
+            // by default include all tags, even without any records
+            $this->setParam('include_zero', 1);
         }
 
-        $findByParams = array_merge(array('sort_field' => 'name', 'include_zero' => true),
-                                    $params,
-                                    array('type' => $for));
+        /* OMEKA, WHAT IS THIS???? if ($record = $this->_getParam('record')) {
+            $filter['record'] = $record;
+        }*/
 
-        $total_tags = $this->_helper->db->count($findByParams);
-        $limit = isset($params['limit']) ? $params['limit'] : null;
-        $tags = $this->_helper->db->findBy($findByParams, $limit);
+        parent::browseAction();
 
-        $browse_for = $for;
-        $sort = array_intersect_key($findByParams, array('sort_field' => '', 'sort_dir' => ''));
+        // get all params after the parent::browseAction() added some defaults, like sorting
+        $params = $this->getAllParams();
+        unset($params['admin'], $params['module'], $params['controller'], $params['action']);
+
+        $sort = array_intersect_key($params, array('sort_field' => '', 'sort_dir' => ''));
 
         //dig up the record types for filtering
         $db = get_db();
@@ -74,7 +75,18 @@ class TagsController extends Omeka_Controller_AbstractActionController
         $csrf = new Omeka_Form_Element_SessionCsrfToken('csrf_token');
         $this->view->csrfToken = $csrf->getToken();
         $this->view->record_types = $record_types;
-        $this->view->assign(compact('tags', 'total_tags', 'browse_for', 'sort'));
+        $this->view->assign(compact('browse_for', 'sort', 'params'));
+    }
+
+    /**
+     * Return the default sorting parameters to use when none are specified.
+     *
+     * @return array|null Array of parameters, with the first element being the
+     *  sort_field parameter, and the second (optionally) the sort_dir.
+     */
+    protected function _getBrowseDefaultSort()
+    {
+        return array('name', 'a');
     }
 
     public function autocompleteAction()

--- a/application/controllers/TagsController.php
+++ b/application/controllers/TagsController.php
@@ -29,7 +29,7 @@ class TagsController extends Omeka_Controller_AbstractActionController
     }
 
     /**
-     *
+     * Browse, filter and search tags
      */
     public function browseAction()
     {
@@ -46,13 +46,9 @@ class TagsController extends Omeka_Controller_AbstractActionController
         } else {
             $browse_for = 'All';
             $this->setParam('type', null);
-            // by default include all tags, even without any records
+            // by default include all tags, even without any relations to records
             $this->setParam('include_zero', 1);
         }
-
-        /* OMEKA, WHAT IS THIS???? if ($record = $this->_getParam('record')) {
-            $filter['record'] = $record;
-        }*/
 
         parent::browseAction();
 


### PR DESCRIPTION
So this is my try on how the admin/tags page could look like. 

Few notes:
- `tagType` param was removed and is replaced by `type` param as expected in `Table_Tag::applySearchFilters()`
- option *All* in **Record Types** dropdown displays all tags with counts for all possible record types, while specific record types like *Item* or others will force to display only tags with relations to that type. I hope I understood your last comment @zerocrates in #784 
- all sort criteria can toggle sort dir
- in `TagsController.php` I couldn't understand the meaning behind the `$filter['record'] = $record;` part. Should I remove it, or does it have some magic usage?