### PR TITLE
Batch-edit redirects

### DIFF
--- a/application/controllers/ItemsController.php
+++ b/application/controllers/ItemsController.php
@@ -214,29 +214,30 @@ class ItemsController extends Omeka_Controller_AbstractActionController
 
         $delete = (boolean) $this->_getParam('submit-batch-delete');
 
+        $params = json_decode($this->_getParam('params'), true) ?: array();
+        unset($params['admin']);
+        unset($params['module']);
+        unset($params['controller']);
+        unset($params['action']);
+        unset($params['submit_search']);
+        unset($params['page']);
+
         $batchAll = (boolean) $this->_getParam('batch-all');
         // Process all searched items.
         if ($batchAll) {
-            $params = json_decode($this->_getParam('params'), true) ?: array();
-            unset($params['admin']);
-            unset($params['module']);
-            unset($params['controller']);
-            unset($params['action']);
-            unset($params['submit_search']);
-            unset($params['page']);
 
             $totalRecords = $this->_helper->db->count($params);
 
             if (empty($totalRecords)) {
                 $this->_helper->flashMessenger(__('No item to batch edit.'), 'error');
-                $this->_helper->redirector('browse', 'items', null, $params);
+                $this->_helper->redirector->gotoUrl('items/browse?'. http_build_query($params));
                 return;
             }
 
             // Special check to avoid the deletion of all the base.
             if ($delete && total_records('Item') == $totalRecords) {
                 $this->_helper->flashMessenger(__('The deletion of all items is forbidden.'), 'error');
-                $this->_helper->redirector('browse', 'items', null, $params);
+                $this->_helper->redirector->gotoUrl('items/browse?'. http_build_query($params));
                 return;
             }
 
@@ -253,7 +254,7 @@ class ItemsController extends Omeka_Controller_AbstractActionController
         $itemIds = $this->_getParam('items');
         if (empty($itemIds)) {
             $this->_helper->flashMessenger(__('You must choose some items to batch edit.'), 'error');
-            $this->_helper->redirector('browse', 'items');
+            $this->_helper->redirector->gotoUrl('items/browse?'. http_build_query($params));
             return;
         }
 
@@ -278,6 +279,7 @@ class ItemsController extends Omeka_Controller_AbstractActionController
             return $this->_batchEditAllSave();
         }
 
+        $redirectToSelection = true;
         $itemIds = $this->_getParam('items');
         if ($itemIds) {
             $metadata = $this->_getParam('metadata');
@@ -354,6 +356,7 @@ class ItemsController extends Omeka_Controller_AbstractActionController
                 $dispatcher->send('Job_ItemBatchEdit', $options);
 
                 if ($delete) {
+                    $redirectToSelection = false;
                     $message = __('The items were successfully deleted!');
                 } else {
                     $message = __('The items were successfully changed!');
@@ -364,7 +367,11 @@ class ItemsController extends Omeka_Controller_AbstractActionController
             $this->_helper->flashMessenger(__('No item to batch edit.'), 'error');
         }
 
-        $this->_helper->redirector('browse', 'items');
+        if ($redirectToSelection) {
+            $this->_helper->redirector->gotoUrl('items/browse?'. http_build_query(array('range' => implode(',', (array) $itemIds))));
+        } else {
+            $this->_helper->redirector('browse', 'items');
+        }
     }
 
     /**
@@ -372,6 +379,7 @@ class ItemsController extends Omeka_Controller_AbstractActionController
      */
     protected function _batchEditAllSave()
     {
+        $redirectToSelection = true;
         // Get the record ids filtered to Omeka_Db_Table::applySearchFilters().
         $params = json_decode($this->_getParam('params'), true) ?: array();
         $totalRecords = $this->_helper->db->count($params);
@@ -419,6 +427,7 @@ class ItemsController extends Omeka_Controller_AbstractActionController
                 $dispatcher->sendLongRunning('Job_ItemBatchEditAll', $options);
 
                 if ($delete) {
+                    $redirectToSelection = false;
                     $message = __('The items are checked and deleted one by one in the background.');
                 } else {
                     $message = __('The items are checked and changed one by one in the background.');
@@ -430,6 +439,10 @@ class ItemsController extends Omeka_Controller_AbstractActionController
             $this->_helper->flashMessenger(__('No item to batch edit.'), 'error');
         }
 
-        $this->_helper->redirector('browse', 'items');
+        if ($redirectToSelection) {
+            $this->_helper->redirector->gotoUrl('items/browse?'. http_build_query($params));
+        } else {
+            $this->_helper->redirector('browse', 'items');
+        }
     }
 }


### PR DESCRIPTION
There's a problem with `$this->_helper->redirector('browse', 'items', null, $params);` and multidimensional `$params` array, such as advanced search criteria, so this pull is fixing it.
Besides, it redirects back to selected items, or to same search params for *batchAll* style of batch-edit. It's practical for direct review of performed changes. So maybe not that useful for `_batchEditAllSave()` action, but definitely for standard batch edit.