### PR TITLE
Default cache busting for all local CSS/JS files

### DIFF
--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -1019,17 +1019,18 @@ function format_date($date, $format = Zend_Date::DATE_MEDIUM)
  * @param string $dir Directory to search for the file. Keeping the default is
  * recommended.
  * @param array $options An array of options.
+ * @param mixed $version Version number. By default OMEKA_VERSION.
  */
-function queue_js_file($file, $dir = 'javascripts', $options = array())
+function queue_js_file($file, $dir = 'javascripts', $options = array(), $version = OMEKA_VERSION)
 {
     if (is_array($file)) {
         foreach ($file as $singleFile) {
-            queue_js_file($singleFile, $dir, $options);
+            queue_js_file($singleFile, $dir, $options, $version);
         }
         return;
     }
 
-    queue_js_url(src($file, $dir, 'js'), $options);
+    queue_js_url(src($file, $dir, 'js', $version), $options);
 }
 
 /**
@@ -1079,16 +1080,17 @@ function queue_js_string($string, $options = array())
  * to include IE-specific styles. Defaults to false.
  * @param string $dir Directory to search for the file.  Keeping the default is
  * recommended.
+ * @param mixed $version Version number. By default OMEKA_VERSION.
  */
-function queue_css_file($file, $media = 'all', $conditional = false, $dir = 'css')
+function queue_css_file($file, $media = 'all', $conditional = false, $dir = 'css', $version = OMEKA_VERSION)
 {
     if (is_array($file)) {
         foreach ($file as $singleFile) {
-            queue_css_file($singleFile, $media, $conditional, $dir);
+            queue_css_file($singleFile, $media, $conditional, $dir, $version);
         }
         return;
     }
-    queue_css_url(css_src($file, $dir), $media, $conditional);
+    queue_css_url(css_src($file, $dir, $version), $media, $conditional);
 }
 
 /**
@@ -1183,11 +1185,12 @@ function head_css()
  * @uses src()
  * @param string $file Should not include the .css extension
  * @param string $dir Defaults to 'css'
+ * @param mixed $version Version number. By default OMEKA_VERSION.
  * @return string
  */
-function css_src($file, $dir = 'css')
+function css_src($file, $dir = 'css', $version = OMEKA_VERSION)
 {
-    return src($file, $dir, 'css');
+    return src($file, $dir, 'css', $version);
 }
 
 /**
@@ -1213,11 +1216,12 @@ function img($file, $dir = 'images')
  * @param string $file The name of the file, without .js extension.
  * @param string $dir The directory in which to look for javascript files.
  * Recommended to leave the default value.
+ * @param mixed $version Version number. By default OMEKA_VERSION.
  * @return string
  */
-function js_tag($file, $dir = 'javascripts')
+function js_tag($file, $dir = 'javascripts', $version = OMEKA_VERSION)
 {
-    $href = src($file, $dir, 'js');
+    $href = src($file, $dir, 'js', $version);
     return '<script type="text/javascript" src="' . html_escape($href) . '" charset="utf-8"></script>';
 }
 
@@ -1229,9 +1233,10 @@ function js_tag($file, $dir = 'javascripts')
  * @param string $file The filename.
  * @param string|null $dir The file's directory.
  * @param string $ext The file's extension.
+ * @param mixed $version Optional version number.
  * @return string
  */
-function src($file, $dir = null, $ext = null)
+function src($file, $dir = null, $ext = null, $version = null)
 {
     if ($ext !== null) {
         $file .= '.' . $ext;
@@ -1239,7 +1244,7 @@ function src($file, $dir = null, $ext = null)
     if ($dir !== null) {
         $file = $dir . '/' . $file;
     }
-    return web_path_to($file);
+    return web_path_to($file) . ($version ? '?v='. $version : '');
 }
 
 /**

--- a/application/tests/suite/Helpers/AssetFunctions/DisplayCssTest.php
+++ b/application/tests/suite/Helpers/AssetFunctions/DisplayCssTest.php
@@ -59,9 +59,32 @@ class Omeka_Helper_DisplayCssTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->_getCssOutput());
     }
 
-    public function testQueueCssSingle()
+    public function testQueueCssSingleWithDefaultVersion()
     {
         queue_css_file('style');
+
+        $styles = array(
+            self::ASSET_PATH_ROOT . '/css/style.css?v='.OMEKA_VERSION
+        );
+
+        $this->_assertStylesheets($this->_getCssOutput(), $styles);
+    }
+
+    public function testQueueCssSingleWithSpecificVersion()
+    {
+        $version = '1.2x';
+        queue_css_file('style', 'all', false, 'css', $version);
+
+        $styles = array(
+            self::ASSET_PATH_ROOT . '/css/style.css?v='.$version
+        );
+
+        $this->_assertStylesheets($this->_getCssOutput(), $styles);
+    }
+
+    public function testQueueCssSingleWithNoVersion()
+    {
+        queue_css_file('style', 'all', false, 'css', null);
 
         $styles = array(
             self::ASSET_PATH_ROOT . '/css/style.css'
@@ -70,9 +93,21 @@ class Omeka_Helper_DisplayCssTest extends PHPUnit_Framework_TestCase
         $this->_assertStylesheets($this->_getCssOutput(), $styles);
     }
 
-    public function testQueueCssArray()
+    public function testQueueCssArrayWithDefaultVersion()
     {
         queue_css_file(array('style', 'jquery-ui'));
+
+        $styles = array(
+            self::ASSET_PATH_ROOT . '/css/style.css?v='.OMEKA_VERSION,
+            self::ASSET_PATH_ROOT . '/css/jquery-ui.css?v='.OMEKA_VERSION
+        );
+
+        $this->_assertStylesheets($this->_getCssOutput(), $styles);
+    }
+
+    public function testQueueCssArrayWithNoVersion()
+    {
+        queue_css_file(array('style', 'jquery-ui'), 'all', false, 'css', null);
 
         $styles = array(
             self::ASSET_PATH_ROOT . '/css/style.css',
@@ -82,9 +117,18 @@ class Omeka_Helper_DisplayCssTest extends PHPUnit_Framework_TestCase
         $this->_assertStylesheets($this->_getCssOutput(), $styles);
     }
 
-    public function testQueueCssWithMedia()
+    public function testQueueCssWithMediaAndDefaultVersion()
     {
         queue_css_file('style', 'screen');
+
+        $path = self::ASSET_PATH_ROOT . '/css/style.css?v='.OMEKA_VERSION;
+
+        $this->_assertStyleLink($this->_getCssOutput(), $path, 'screen');
+    }
+
+    public function testQueueCssWithMediaAndNoVersion()
+    {
+        queue_css_file('style', 'screen', false, 'css', null);
 
         $path = self::ASSET_PATH_ROOT . '/css/style.css';
 

--- a/application/tests/suite/Helpers/AssetFunctions/DisplayJsTest.php
+++ b/application/tests/suite/Helpers/AssetFunctions/DisplayJsTest.php
@@ -57,9 +57,21 @@ class Omeka_Helper_DisplayJsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->_getJsOutput(false));
     }
 
-    public function testQueueJs()
+    public function testQueueJsWithDefaultVersion()
     {
         queue_js_file(array('items-search', 'vendor/tiny_mce/tiny_mce'));
+
+        $scripts = array(
+            self::ASSET_PATH_ROOT . '/javascripts/items-search.js?v='.OMEKA_VERSION,
+            self::ASSET_PATH_ROOT . '/javascripts/vendor/tiny_mce/tiny_mce.js?v='.OMEKA_VERSION
+        );
+
+        $this->_assertScriptsIncluded($this->_getJsOutput(), $scripts);
+    }
+
+    public function testQueueJsWithNoVersion()
+    {
+        queue_js_file(array('items-search', 'vendor/tiny_mce/tiny_mce'), 'javascripts', array(), null);
 
         $scripts = array(
             self::ASSET_PATH_ROOT . '/javascripts/items-search.js',

--- a/application/tests/suite/Helpers/AssetFunctions/JsTest.php
+++ b/application/tests/suite/Helpers/AssetFunctions/JsTest.php
@@ -20,11 +20,32 @@ class Omeka_Helper_JsTest extends PHPUnit_Framework_TestCase
         $this->view->addAssetPath(VIEW_SCRIPTS_DIR, 'http://fake.local/path/to/omeka');
     }
 
-    public function testOutputsScriptTagWithHref()
+    public function testOutputsScriptTagWithHrefAndDefaultVersion()
+    {
+        // Test with Contains to avoid matching issues with newlines.
+        $this->assertContains('<script type="text/javascript" src="http://fake.local/path/to/omeka/javascripts/vendor/jquery.js?v='.OMEKA_VERSION.'" charset="utf-8"></script>',
+                            $this->_getJsTag());
+    }
+
+    public function testOutputsScriptTagWithHrefAndSpecificVersion()
+    {
+        $version = '1.2x';
+        // Test with Contains to avoid matching issues with newlines.
+        $this->assertContains('<script type="text/javascript" src="http://fake.local/path/to/omeka/javascripts/vendor/jquery.js?v='.$version.'" charset="utf-8"></script>',
+                            $this->_getJsTag($version));
+    }
+
+    public function testOutputsScriptTagWithHrefAndNoVersion()
     {
         // Test with Contains to avoid matching issues with newlines.
         $this->assertContains('<script type="text/javascript" src="http://fake.local/path/to/omeka/javascripts/vendor/jquery.js" charset="utf-8"></script>',
-                            js_tag('vendor/jquery'));
+                            $this->_getJsTag(null));
+    }
+
+    private function _getJsTag($version = OMEKA_VERSION, $dir = 'javascripts')
+    {
+        // Returns the JS tag with specific version
+        return js_tag('vendor/jquery', $dir, $version);
     }
 
     public function tearDown()


### PR DESCRIPTION
This was inspired by #613 and the actual upgrade to Omeka 2.5, where manual clearing of cache in browser was needed.
I believe this should be default feature for all local CSS/JS files. By default using `OMEKA_VERSION`, with possibility to disable it by passing any *empty* value, or adapt it after for example plugin version for plugin specific assets.
