### PR TITLE
Allow zero as legit element text

### DIFF
--- a/application/models/Mixin/ElementText.php
+++ b/application/models/Mixin/ElementText.php
@@ -431,7 +431,7 @@ class Mixin_ElementText extends Omeka_Record_Mixin_AbstractMixin
                     }
                     // Only add the element text if it's not empty.  There
                     // should be no empty element texts in the DB.
-                    if (!empty($elementText['text'])) {
+                    if (strlen($elementText['text'])) {
                         $this->addTextForElement($element, $elementText['text'], $elementText['html']);
                     }
                 }
@@ -442,7 +442,7 @@ class Mixin_ElementText extends Omeka_Record_Mixin_AbstractMixin
     private function _addTextsByElementId(array $texts)
     {
         foreach ($texts as $key => $info) {
-            if (empty($info['text'])) {
+            if (!strlen($info['text'])) {
                 continue;
             }
             $text = new ElementText;
@@ -521,7 +521,7 @@ class Mixin_ElementText extends Omeka_Record_Mixin_AbstractMixin
                 );
 
                 // Ignore fields that are empty (no text)
-                if (empty($elementText)) {
+                if (!strlen($elementText)) {
                     continue;
                 }
 


### PR DESCRIPTION
There are some cases, where custom elements in Item Type Metada set may need "0" as valid text, that's why this PR.

Another possible update would be check against `strlen(trim($var))`. The current `empty($var)` check doesn't filter out *space*, that's why I made only changes that will allow "0" come in, for now, everything else stays as it was. Do you agree with trimming?