### PR TITLE
Enable multiple files upload for items

### DIFF
--- a/admin/themes/default/javascripts/items.js
+++ b/admin/themes/default/javascripts/items.js
@@ -258,19 +258,23 @@ Omeka.Items = {};
     Omeka.Items.enableAddFiles = function (label) {
         var filesDiv = $('#files-metadata .files');
         var fileInput = filesDiv.find('input');
+        var supportsMultiple = ('multiple' in fileInput.get(0));
         // add mutliple file upload support only for browsers that support it
-        if ('multiple' in fileInput.get(0)) {
+        if (supportsMultiple) {
             fileInput.attr({'multiple': '', 'name': 'file[]'});
-            $('#file-inputs').hide();
-            return;
         }
 
         var link = $('<a href="#" id="add-file" class="add-file button">' + label + '</a>');
         link.click(function (event) {
             event.preventDefault();
             var inputs = filesDiv.find('input');
-            var inputCount = inputs.length;
-            var fileHtml = '<input name="file[' + inputCount + ']" type="file"></div>';
+            var fileHtml = '';
+            if (supportsMultiple) {
+                fileHtml = '<input name="file[]" type="file" multiple>';
+            } else {
+                var inputCount = inputs.length;
+                fileHtml = '<input name="file[' + inputCount + ']" type="file">';
+            }
             $(fileHtml).insertAfter(inputs.last()).hide().slideDown(200, function () {
                 // Extra show fixes IE bug.
                 $(this).show();


### PR DESCRIPTION
Multiple file input is not supported on IE9=< and on Android (works in Chrome on Android 5+), so it feels like very practical enhancement for newer browsers.