### PR TITLE
Update bootstrap.php for https offloading

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -49,6 +49,7 @@ define('SCRIPTS_DIR', APP_DIR . '/scripts');
 if ((isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true))
     || (isset($_SERVER['HTTP_SCHEME']) && $_SERVER['HTTP_SCHEME'] == 'https')
     || (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443)
+    || ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
 ) {
     $base_root = 'https';
 } else {


### PR DESCRIPTION
In the case of an upstream load balancer (such as haproxy) that handles https while backend application servers talk to the load balancer via http, this change allows backend application server hosts to correctly pass along URLs for resources such as theme CSS when the client connects to the load balancer using https.