### PR TITLE
ReCaptcha v2 support

### DIFF
--- a/application/controllers/SettingsController.php
+++ b/application/controllers/SettingsController.php
@@ -75,7 +75,8 @@ class SettingsController extends Omeka_Controller_AbstractActionController
                     'html_purifier_allowed_html_elements',
                     'html_purifier_allowed_html_attributes',
                     Omeka_Captcha::PUBLIC_KEY_OPTION,
-                    Omeka_Captcha::PRIVATE_KEY_OPTION
+                    Omeka_Captcha::PRIVATE_KEY_OPTION,
+                    Omeka_Captcha::VERSION_OPTION
                 );
                 foreach ($form->getValues() as $key => $value) {
                     if (in_array($key, $options)) {

--- a/application/forms/SecuritySettings.php
+++ b/application/forms/SecuritySettings.php
@@ -49,7 +49,7 @@ class Omeka_Form_SecuritySettings extends Omeka_Form
         $this->addElement('text', Omeka_Captcha::PUBLIC_KEY_OPTION,
             array(
                 'label' => __('ReCaptcha Public Key'),
-                'description' => __('Enter public key from recaptcha.net. Both this and the private key must be filled in to secure public forms.'),
+                'description' => __('Enter public key from %s. Both this and the private key must be filled in to secure public forms.', '<a href="https://developers.google.com/recaptcha/">https://developers.google.com/recaptcha/</a>'),
                 'value' => get_option(Omeka_Captcha::PUBLIC_KEY_OPTION)
             )
         );
@@ -57,8 +57,17 @@ class Omeka_Form_SecuritySettings extends Omeka_Form
         $this->addElement('text', Omeka_Captcha::PRIVATE_KEY_OPTION,
             array(
                 'label' => __('ReCaptcha Private Key'),
-                'description' => __('Enter private key from recaptcha.net. Both this and the public key must be filled in to secure public forms.'),
+                'description' => __('Enter private key from %s. Both this and the public key must be filled in to secure public forms.', '<a href="https://developers.google.com/recaptcha/">https://developers.google.com/recaptcha/</a>'),
                 'value' => get_option(Omeka_Captcha::PRIVATE_KEY_OPTION)
+            )
+        );
+
+        $this->addElement('select', Omeka_Captcha::VERSION_OPTION,
+            array(
+                'label' => __('ReCaptcha Version'),
+                'description' => __('Choose which ReCaptcha version you\'re using. Note that ReCaptcha v1 is deprecated and Public and Private Key from ReCaptcha v1 doesn\'t work with ReCaptcha v2.'),
+                'value' => get_option(Omeka_Captcha::VERSION_OPTION) ?: '',
+                'multiOptions' => array('' => 'ReCaptcha v1', 'v2' => 'ReCaptcha v2')
             )
         );
 
@@ -101,6 +110,7 @@ class Omeka_Form_SecuritySettings extends Omeka_Form
             array(
                 Omeka_Captcha::PUBLIC_KEY_OPTION,
                 Omeka_Captcha::PRIVATE_KEY_OPTION,
+                Omeka_Captcha::VERSION_OPTION,
             ),
             'captcha', array('legend' => __('Captcha'))
         );

--- a/application/forms/SecuritySettings.php
+++ b/application/forms/SecuritySettings.php
@@ -65,7 +65,7 @@ class Omeka_Form_SecuritySettings extends Omeka_Form
         $this->addElement('select', Omeka_Captcha::VERSION_OPTION,
             array(
                 'label' => __('ReCaptcha Version'),
-                'description' => __('Choose which ReCaptcha version you\'re using. Note that ReCaptcha v1 is deprecated and Public and Private Key from ReCaptcha v1 doesn\'t work with ReCaptcha v2.'),
+                'description' => __('Choose which ReCaptcha version you\'re using. Note that ReCaptcha v1 is deprecated and will not work after March 31, 2018.'),
                 'value' => get_option(Omeka_Captcha::VERSION_OPTION) ?: '',
                 'multiOptions' => array('' => 'ReCaptcha v1', 'v2' => 'ReCaptcha v2')
             )

--- a/application/libraries/Ghost/Captcha/ReCaptcha2.php
+++ b/application/libraries/Ghost/Captcha/ReCaptcha2.php
@@ -147,11 +147,11 @@ class Ghost_Captcha_ReCaptcha2 extends Zend_Captcha_Base
     public function setOption($key, $value)
     {
         $service = $this->getService();
-        if (isset($this->_serviceParams[$key])) {
+        if (array_key_exists($key, $this->_serviceParams)) {
             $service->setParam($key, $value);
             return $this;
         }
-        if (isset($this->_serviceAttributes[$key])) {
+        if (array_key_exists($key, $this->_serviceAttributes)) {
             $service->setAttribute($key, $value);
             return $this;
         }

--- a/application/libraries/Ghost/Captcha/ReCaptcha2.php
+++ b/application/libraries/Ghost/Captcha/ReCaptcha2.php
@@ -1,0 +1,239 @@
+<?php
+
+class Ghost_Captcha_ReCaptcha2 extends Zend_Captcha_Base
+{
+    /**
+     * ReCaptcha response field name
+     * @var string
+     */
+    protected $_RESPONSE  = 'g-recaptcha-response';
+
+    /**
+     * Recaptcha service object
+     *
+     * @var Ghost_Service_ReCaptcha2
+     */
+    protected $_service;
+
+    /**
+     * Parameters defined by the service
+     *
+     * @var array
+     */
+    protected $_serviceParams = array();
+
+    /**
+     * Options defined by the service
+     *
+     * @var array
+     */
+    protected $_serviceAttributes = array();
+
+    /**#@+
+     * Error codes
+     */
+    const MISSING_VALUE = 'missingValue';
+    const ERR_CAPTCHA   = 'errCaptcha';
+    const BAD_CAPTCHA   = 'badCaptcha';
+    /**#@-*/
+
+    /**
+     * Error messages
+     * @var array
+     */
+    protected $_messageTemplates = array(
+        self::MISSING_VALUE => 'Missing captcha fields',
+        self::ERR_CAPTCHA   => 'Failed to validate captcha',
+        self::BAD_CAPTCHA   => 'Captcha value is wrong: %value%',
+    );
+
+    /**
+     * Retrieve ReCaptcha Private key
+     *
+     * @return string
+     */
+    public function getPrivkey()
+    {
+        return $this->getService()->getPrivateKey();
+    }
+
+    /**
+     * Retrieve ReCaptcha Public key
+     *
+     * @return string
+     */
+    public function getPubkey()
+    {
+        return $this->getService()->getPublicKey();
+    }
+
+    /**
+     * Set ReCaptcha Private key
+     *
+     * @param string $privkey
+     * @return Ghost_Captcha_ReCaptcha2
+     */
+    public function setPrivkey($privkey)
+    {
+        $this->getService()->setPrivateKey($privkey);
+        return $this;
+    }
+
+    /**
+     * Set ReCaptcha public key
+     *
+     * @param string $pubkey
+     * @return Ghost_Captcha_ReCaptcha2
+     */
+    public function setPubkey($pubkey)
+    {
+        $this->getService()->setPublicKey($pubkey);
+        return $this;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param array|Zend_Config $options
+     */
+    public function __construct($options = null)
+    {
+        $this->setService(new Ghost_Service_ReCaptcha2());
+        $this->_serviceParams = $this->getService()->getParams();
+        $this->_serviceAttributes = $this->getService()->getAttributes();
+
+        parent::__construct($options);
+
+        if ($options instanceof Zend_Config) {
+            $options = $options->toArray();
+        }
+        if (!empty($options)) {
+            $this->setOptions($options);
+        }
+    }
+
+    /**
+     * Set service object
+     *
+     * @param  Ghost_Service_ReCaptcha2 $service
+     * @return Ghost_Captcha_ReCaptcha2
+     */
+    public function setService(Ghost_Service_ReCaptcha2 $service)
+    {
+        $this->_service = $service;
+        return $this;
+    }
+
+    /**
+     * Retrieve ReCaptcha service object
+     *
+     * @return Ghost_Service_ReCaptcha2
+     */
+    public function getService()
+    {
+        return $this->_service;
+    }
+
+    /**
+     * Set option
+     *
+     * If option is a service parameter, proxies to the service. The same
+     * goes for any service options (distinct from service params)
+     *
+     * @param  string $key
+     * @param  mixed $value
+     * @return Zend_Captcha_ReCaptcha
+     */
+    public function setOption($key, $value)
+    {
+        $service = $this->getService();
+        if (isset($this->_serviceParams[$key])) {
+            $service->setParam($key, $value);
+            return $this;
+        }
+        if (isset($this->_serviceAttributes[$key])) {
+            $service->setAttribute($key, $value);
+            return $this;
+        }
+        return parent::setOption($key, $value);
+    }
+
+    /**
+     * Generate captcha
+     *
+     * @see Zend_Form_Captcha_Adapter::generate()
+     * @return string
+     */
+    public function generate()
+    {
+        return "";
+    }
+
+    /**
+     * Validate captcha
+     *
+     * @see    Zend_Validate_Interface::isValid()
+     * @param  mixed      $value
+     * @param  array|null $context
+     * @return boolean
+     */
+    public function isValid($value, $context = null)
+    {
+        if (!is_array($value) && !is_array($context)) {
+            $this->_error(self::MISSING_VALUE);
+            return false;
+        }
+
+        if (!is_array($value) && is_array($context)) {
+            $value = $context;
+        }
+
+        if (empty($value[$this->_RESPONSE])) {
+            $this->_error(self::MISSING_VALUE);
+            return false;
+        }
+
+        $service = $this->getService();
+
+        $res = $service->verify($value[$this->_RESPONSE]);
+
+        if (!$res) {
+            $this->_error(self::ERR_CAPTCHA);
+            return false;
+        }
+
+        if (!$res->isValid()) {
+            $this->_error(self::BAD_CAPTCHA, $res->getErrorCodes());
+            $service->setParam('error', $res->getErrorCodes());
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Render captcha
+     *
+     * @param  Zend_View_Interface $view
+     * @param  mixed $element
+     * @return string
+     */
+    public function render(Zend_View_Interface $view = null, $element = null)
+    {
+        $name = null;
+        if ($element instanceof Zend_Form_Element) {
+            $name = $element->getBelongsTo();
+        }
+        return $this->getService()->getHtml($name);
+    }
+
+    /**
+     * Get captcha decorator
+     *
+     * @return string
+     */
+    public function getDecorator()
+    {
+        return "Captcha_ReCaptcha2";
+    }
+}

--- a/application/libraries/Ghost/Exception.php
+++ b/application/libraries/Ghost/Exception.php
@@ -1,0 +1,5 @@
+<?php
+
+class Ghost_Exception extends Exception {
+  
+}

--- a/application/libraries/Ghost/Form/Decorator/Captcha/ReCaptcha2.php
+++ b/application/libraries/Ghost/Form/Decorator/Captcha/ReCaptcha2.php
@@ -1,0 +1,39 @@
+<?php
+
+class Ghost_Form_Decorator_Captcha_ReCaptcha2 extends Zend_Form_Decorator_Abstract
+{
+    /**
+     * Render captcha
+     *
+     * @param  string $content
+     * @return string
+     */
+    public function render($content)
+    {
+        $element = $this->getElement();
+        if (!$element instanceof Zend_Form_Element_Captcha) {
+            return $content;
+        }
+
+        $view    = $element->getView();
+        if (null === $view) {
+            return $content;
+        }
+
+        $placement     = $this->getPlacement();
+        $separator     = $this->getSeparator();
+        $captcha       = $element->getCaptcha();
+        $markup        = $captcha->render($view, $element);
+
+        switch ($placement) {
+            case 'PREPEND':
+                $content = $markup . $separator . $content;
+                break;
+            case 'APPEND':
+            default:
+                $content = $content . $separator . $markup;
+        }
+        return $content;
+    }
+}
+

--- a/application/libraries/Ghost/README.md
+++ b/application/libraries/Ghost/README.md
@@ -1,0 +1,110 @@
+ZF1 - Google ReCaptcha v2 project
+===================
+
+Zend Framework 1 ships with ReCacaptcha v1. This project aims to transfer the full functionality of Google ReCaptcha v2 to forms and services.
+
+
+## Install
+
+Download package, copy files to library / vendor dir. Modify Your application.ini. Project assumes that the autoloader will be able to read defined namespaces so all references to require_once has been removed.
+
+```
+; +-----------------------------+
+; | Include path and autoloader |
+; +-----------------------------+
+includePaths.library = BASE_PATH "/library"
+autoloaderNamespaces[] = "Ghost"
+```
+
+## Usage
+
+To use ReCaptcha V2 element first you need to define additional paths (inside form / by extending Zend_Form):
+
+```php
+$form->addElementPrefixPath(
+    'Ghost', 
+    'Ghost'
+);
+            
+$form->addElementPrefixPath(
+    'Ghost_Form_Decorator', 
+    'Ghost/Form/Decorator',
+    self::DECORATOR // 'decorator'
+);
+```
+
+To get ReCaptcha v2 working you only need to change the name of the component:
+
+```php
+$this->addElement('captcha', 'captcha', array(
+    'label' => 'Please solve Captcha puzzle:',
+    'required' => true,
+    'captcha' => array(
+        'captcha' => 'ReCaptcha2',
+        'hl' => 'en', // browser's language by deafult, this line is not required
+        'theme' => 'light', // see options below
+        'pubkey' => 'Your public key goes here',
+        'privkey' => 'Your private key goes here'
+    )
+));
+```
+
+To include paths directly, you can use: 
+
+```php
+$captcha = new Zend_Form_Element_Captcha('captcha', array(
+    'label' => 'Please solve Captcha puzzle:',
+    'prefixPath' => array(
+        array('prefix' => 'Ghost', 'path' => 'Ghost'),
+        Zend_Form::DECORATOR => array('prefix' => 'Ghost_Form_Decorator', 'path' => 'Ghost/Form/Decorator'),
+    ),
+    'captcha' => array(
+        'captcha' => 'ReCaptcha2',
+        'pubkey' => 'Your public key goes here',
+        'privkey' => 'Your private key goes here'
+        'theme' => 'light', // see options below
+    )
+));
+```
+
+## Options
+
+Ghost_Service_ReCaptcha2 constructor allows two different type of options: params and attributes. Both refers to https://developers.google.com/recaptcha/docs/display configuration options.
+Parameters are published inside 'script' tag, while the attributes referes to 'div.g-recaptcha element'. By default they are defined as:
+
+```php
+/**
+ * Parameters for the script object
+ *
+ * @var array
+ */
+protected $_params = array(
+    'onload' => '',
+    'render' => 'onload',
+    'hl'     => ''
+);
+    
+/**
+ * Attributes for div element
+ *
+ * @var array
+ */
+protected $_attributes = array(
+    'class'            => 'g-recaptcha',
+    'theme'            => 'light',
+    'type'             => 'image',
+    'tabindex'         => 0,
+    'callback'         => '',
+    'expired-callback' => ''
+);
+```
+All attributes are rendered with htmlentities() function.
+
+Zend_Form will render ReCaptcha2 element as concatenation of script and div elements. If you prefer to define JS separately (for example with RequireJS), you can embed elements on the page using two additional methods:
+Ghost_Service_ReCaptcha2::getHtmlHead() - <script> only
+Ghost_Service_ReCaptcha2::getHtmlBody() - <div class="g-recaptcha"></div> only
+
+## External links
+
+* http://framework.zend.com/
+* https://www.google.com/recaptcha/intro/index.html

--- a/application/libraries/Ghost/README.md
+++ b/application/libraries/Ghost/README.md
@@ -79,9 +79,9 @@ Parameters are published inside 'script' tag, while the attributes referes to 'd
  * @var array
  */
 protected $_params = array(
-    'onload' => '',
+    'onload' => null,
     'render' => 'onload',
-    'hl'     => ''
+    'hl'     => null
 );
     
 /**
@@ -94,8 +94,8 @@ protected $_attributes = array(
     'theme'            => 'light',
     'type'             => 'image',
     'tabindex'         => 0,
-    'callback'         => '',
-    'expired-callback' => ''
+    'callback'         => null,
+    'expired-callback' => null
 );
 ```
 All attributes are rendered with htmlentities() function.

--- a/application/libraries/Ghost/Service/Exception.php
+++ b/application/libraries/Ghost/Service/Exception.php
@@ -1,0 +1,5 @@
+<?php
+
+class Ghost_Service_Exception extends Ghost_Exception {
+  
+}

--- a/application/libraries/Ghost/Service/ReCaptcha2.php
+++ b/application/libraries/Ghost/Service/ReCaptcha2.php
@@ -1,0 +1,462 @@
+<?php
+
+class Ghost_Service_ReCaptcha2 extends Zend_Service_Abstract
+{
+    /**
+     * URI to the secure API
+     *
+     * @var string
+     */
+    const API_SECURE_SERVER = 'https://www.google.com/recaptcha/api';
+    
+    /**
+     * URI to the verify server
+     *
+     * @var string
+     */
+    const VERIFY_SERVER = 'https://www.google.com/recaptcha/api/siteverify';
+    
+    /**
+     * Public key used when displaying the captcha
+     *
+     * @var string
+     */
+    protected $_publicKey = null;
+
+    /**
+     * Private key used when verifying user input
+     *
+     * @var string
+     */
+    protected $_privateKey = null;
+
+    /**
+     * Ip address used when verifying user input
+     *
+     * @var string
+     */
+    protected $_ip = null;
+    
+    /**
+     * Response from the verify server
+     *
+     * @var Ghost_Service_ReCaptcha2_Response
+     */
+    protected $_response = null;
+    
+    /**
+     * Parameters for the script object
+     *
+     * @var array
+     */
+    protected $_params = array(
+        'onload' => '',
+        'render' => 'onload',
+        'hl'     => '' // by default browser's locale
+    );
+    
+    /**
+     * Attributes for div element
+     *
+     * @var array
+     */
+    protected $_attributes = array(
+        'class'            => 'g-recaptcha',
+        'theme'            => 'light',
+        'type'             => 'image',
+        'tabindex'         => 0,
+        'callback'         => '',
+        'expired-callback' => ''
+    );
+
+
+    /**
+     * Class constructor
+     *
+     * @param string $publicKey
+     * @param string $privateKey
+     * @param array $params
+     * @param array $options
+     * @param string $ip
+     * @param array|Zend_Config $params
+     */
+    public function __construct($publicKey = null, $privateKey = null,
+                                $params = null, $attributes = null, $ip = null)
+    {
+        if ($publicKey !== null) {
+            $this->setPublicKey($publicKey);
+        }
+
+        if ($privateKey !== null) {
+            $this->setPrivateKey($privateKey);
+        }
+
+        if ($ip !== null) {
+            $this->setIp($ip);
+        } else if (isset($_SERVER['REMOTE_ADDR'])) {
+            $this->setIp($_SERVER['REMOTE_ADDR']);
+        }
+
+        if ($params !== null) {
+            $this->setParams($params);
+        }
+
+        if ($attributes !== null) {
+            $this->setAttributes($attributes);
+        }
+    }
+    
+    /**
+     * Serialize as string
+     *
+     * When the instance is used as a string it will display the recaptcha.
+     * Since we can't throw exceptions within this method we will trigger
+     * a user warning instead.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        try {
+            $return = $this->getHtml();
+        } catch (Exception $e) {
+            $return = '';
+            trigger_error($e->getMessage(), E_USER_WARNING);
+        }
+
+        return $return;
+    }
+    
+    /**
+     * Set the ip property
+     *
+     * @param string $ip
+     * @return Ghost_Service_ReCaptcha2
+     */
+    public function setIp($ip)
+    {
+        $this->_ip = $ip;
+
+        return $this;
+    }
+
+    /**
+     * Get the ip property
+     *
+     * @return string
+     */
+    public function getIp()
+    {
+        return $this->_ip;
+    }
+    
+    /**
+     * Get the public key
+     *
+     * @return string
+     */
+    public function getPublicKey()
+    {
+        return $this->_publicKey;
+    }
+
+    /**
+     * Set the public key
+     *
+     * @param string $publicKey
+     * @return Ghost_Service_ReCaptcha2
+     */
+    public function setPublicKey($publicKey)
+    {
+        $this->_publicKey = $publicKey;
+
+        return $this;
+    }
+
+    /**
+     * Get the private key
+     *
+     * @return string
+     */
+    public function getPrivateKey()
+    {
+        return $this->_privateKey;
+    }
+
+    /**
+     * Set the private key
+     *
+     * @param string $privateKey
+     * @return Ghost_Service_ReCaptcha2
+     */
+    public function setPrivateKey($privateKey)
+    {
+        $this->_privateKey = $privateKey;
+
+        return $this;
+    }
+    
+    /**
+     * Get a single parameter
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function getParam($key)
+    {
+        return $this->_params[$key];
+    }
+    
+    /**
+     * Set a single parameter
+     *
+     * @param string $key
+     * @param string $value
+     * @return Ghost_Service_ReCaptcha2
+     */
+    public function setParam($key, $value)
+    {       
+        $this->_params[$key] = $value;
+
+        return $this;
+    }
+    
+    /**
+     * Get the parameter array
+     *
+     * @return array
+     */
+    public function getParams()
+    {
+        return $this->_params;
+    }
+    
+    /**
+     * Set parameters
+     *
+     * @param array|Zend_Config $params
+     * @return Ghost_Service_ReCaptcha2
+     * @throws Ghost_Service_ReCaptcha2_Exception
+     */
+    public function setParams($params)
+    {
+        if ($params instanceof Zend_Config) {
+            $params = $params->toArray();
+        }
+
+        if (is_array($params)) {
+            foreach ($params as $k => $v) {
+                $this->setParam($k, $v);
+            }
+        } else {
+            throw new Ghost_Service_ReCaptcha2_Exception(
+                'Expected array or Zend_Config object'
+            );
+        }
+
+        return $this;
+    }
+    
+    /**
+     * Get a single attribute
+     *
+     * @param string $key
+     * @return mixed
+     */
+    public function getAttribute($key)
+    {
+        return $this->_attributes[$key];
+    }
+    
+    /**
+     * Set a single attribute
+     *
+     * @param string $key
+     * @param string $value
+     * @return Ghost_Service_ReCaptcha2
+     */
+    public function setAttribute($key, $value)
+    {
+        $key = strtolower($key);
+        if (!array_key_exists($key, $this->_attributes)) {
+            return $this;
+        }
+        $this->_attributes[$key] = $value;
+
+        return $this;
+    }
+    
+    /**
+     * Get attributes array
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->_attributes;
+    }
+    
+    /**
+     * Set attributes array
+     *
+     * @param array|Zend_Config $attributes
+     * @return Ghost_Service_ReCaptcha2
+     * @throws Ghost_Service_ReCaptcha2_Exception
+     */
+    public function setAttributes($attributes)
+    {
+        if ($attributes instanceof Zend_Config) {
+            $attributes = $attributes->toArray();
+        }
+
+        if (is_array($attributes)) {
+            foreach ($attributes as $k => $v) {
+                $this->setAttribute($k, $v);
+            }
+        } else {
+            throw new Ghost_Service_ReCaptcha2_Exception(
+                'Expected array or Zend_Config object'
+            );
+        }
+
+        return $this;
+    }
+    
+    /**
+     * Get HTML for script element
+     * 
+     * @return string
+     */
+    public function getHtmlHead()
+    {
+        $host = self::API_SECURE_SERVER;
+
+        $renderPart = '?render=onload';
+        if (!empty($this->_params['render'])) {
+            $renderPart = '?render=' . urlencode($this->getParam('render'));
+        }
+        
+        $langPart = '';
+        if (!empty($this->_params['hl'])) {
+            $langPart = '&hl=' . urlencode($this->getParam('hl'));
+        }
+        
+        $onloadPart = '';
+        if (!empty($this->_params['onload'])) {
+            $onloadPart = '&onload=' . urlencode($this->getParam('onload'));
+        }
+        
+        $return = <<<HTML
+<script type="text/javascript"
+   src="{$host}.js{$renderPart}{$langPart}{$onloadPart}" async="async" defer="defer">
+</script>
+HTML;
+        return $return;
+    }
+    
+    /**
+     * Get HTML for ReCaptcha div element
+     * 
+     * @return string
+     * @throws Ghost_Service_ReCaptcha2_Exception
+     */
+    public function getHtmlBody()
+    {
+        if ($this->_publicKey === null) {
+            throw new Ghost_Service_ReCaptcha2_Exception('Missing public key');
+        }
+        
+        $elemClass = 'g-recaptcha';
+        if (!empty($this->_attributes['class'])) {
+            $elemClass = htmlentities($this->getAttribute('class'));
+        }
+        
+        $dataTheme = '';
+        if (!empty($this->_attributes['theme'])) {
+            $dataTheme = 'data-theme="' . htmlentities($this->getAttribute('theme')) . '"';
+        }
+        
+        $dataType = '';
+        if (!empty($this->_attributes['type'])) {
+            $dataType = 'data-type="' . htmlentities($this->getAttribute('type')) . '"';
+        }
+        
+        $dataTabindex = '';
+        if (!empty($this->_attributes['tabindex'])) {
+            $dataTabindex = 'data-tabindex="' . intval($this->getAttribute('tabindex')) . '"';
+        }
+        
+        $dataCallback = '';
+        if (!empty($this->_attributes['callback'])) {
+            $dataCallback = 'data-callback="' . htmlentities($this->getAttribute('callback')) . '"';
+        }
+        
+        $dataExpiredCallback = '';
+        if (!empty($this->_attributes['expired-callback'])) {
+            $dataExpiredCallback = 'data-expired-callback="' . htmlentities($this->getAttribute('expired-callback')) . '"';
+        }
+        
+        $return = <<<HTML
+<div class="{$elemClass}" data-sitekey="{$this->_publicKey}" {$dataTheme} {$dataType} {$dataTabindex} {$dataCallback} {$dataExpiredCallback}></div>
+HTML;
+        return $return;
+    }
+    
+    /**
+     * Get the HTML code for the captcha
+     *
+     * This method uses the public key to fetch a recaptcha form.
+     * 
+     * @return string
+     */
+    public function getHtml()
+    {
+        return $this->getHtmlHead() . $this->getHtmlBody();
+    }
+    
+    /**
+     * Post a solution to the verify server
+     *
+     * @param string $responseField
+     * @return Zend_Http_Response
+     * @throws Ghost_Service_ReCaptcha2_Exception
+     */
+    protected function _post($responseField)
+    {
+        if ($this->_privateKey === null) {
+            throw new Ghost_Service_ReCaptcha2_Exception('Missing private key');
+        }
+
+        /* Fetch an instance of the http client */
+        $httpClient = self::getHttpClient();
+        $httpClient->resetParameters(true);
+
+        $postParams = array('secret'     => $this->_privateKey,
+                            'remoteip'   => $this->_ip,
+                            'response'   => $responseField);
+
+        /* Make the POST and return the response */
+        return $httpClient->setUri(self::VERIFY_SERVER)
+                          ->setParameterPost($postParams)
+                          ->request(Zend_Http_Client::POST);
+    }
+    
+    /**
+     * Verify the user input
+     *
+     * This method calls up the post method and returns a
+     * Ghost_Service_ReCaptcha2_Response object.
+     *
+     * @param string $responseField
+     * @return Ghost_Service_ReCaptcha2_Response
+     */
+    public function verify($responseField)
+    {
+        if (empty($responseField)) {
+            throw new Ghost_Service_ReCaptcha2_Exception('Missing response field');
+        }
+        $response = $this->_post($responseField);
+
+        return new Ghost_Service_ReCaptcha2_Response(null, null, $response);
+    }
+}

--- a/application/libraries/Ghost/Service/ReCaptcha2.php
+++ b/application/libraries/Ghost/Service/ReCaptcha2.php
@@ -50,9 +50,9 @@ class Ghost_Service_ReCaptcha2 extends Zend_Service_Abstract
      * @var array
      */
     protected $_params = array(
-        'onload' => '',
+        'onload' => null,
         'render' => 'onload',
-        'hl'     => '' // by default browser's locale
+        'hl'     => null // by default browser's locale
     );
     
     /**
@@ -65,8 +65,8 @@ class Ghost_Service_ReCaptcha2 extends Zend_Service_Abstract
         'theme'            => 'light',
         'type'             => 'image',
         'tabindex'         => 0,
-        'callback'         => '',
-        'expired-callback' => ''
+        'callback'         => null,
+        'expired-callback' => null
     );
 
 

--- a/application/libraries/Ghost/Service/ReCaptcha2/Exception.php
+++ b/application/libraries/Ghost/Service/ReCaptcha2/Exception.php
@@ -1,0 +1,5 @@
+<?php
+
+class Ghost_Service_ReCaptcha2_Exception extends Ghost_Service_Exception {
+  
+}

--- a/application/libraries/Ghost/Service/ReCaptcha2/Response.php
+++ b/application/libraries/Ghost/Service/ReCaptcha2/Response.php
@@ -1,0 +1,129 @@
+<?php
+
+class Ghost_Service_ReCaptcha2_Response
+{
+    /**
+     * Status
+     *
+     * true if the response is valid or false otherwise
+     *
+     * @var boolean
+     */
+    protected $_status = null;
+
+    /**
+     * Error codes
+     *
+     * The error codes if the status is false. The different error codes can be found in the
+     * recaptcha API docs.
+     *
+     * @var array
+     */
+    protected $_errorCodes = array();
+
+    /**
+     * Class constructor used to construct a response
+     *
+     * @param string $status
+     * @param array $errorCodes
+     * @param Zend_Http_Response $httpResponse If this is set the content will override $status and $errorCode
+     */
+    public function __construct($status = null, array $errorCodes = null, Zend_Http_Response $httpResponse = null)
+    {
+        if ($status !== null) {
+            $this->setStatus($status);
+        }
+
+        if ($errorCodes !== null) {
+            $this->setErrorCodes($errorCodes);
+        }
+
+        if ($httpResponse !== null) {
+            $this->setFromHttpResponse($httpResponse);
+        }
+    }
+
+    /**
+     * Set the status
+     *
+     * @param string $status
+     * @return Ghost_Service_ReCaptcha2_Response
+     */
+    public function setStatus($status)
+    {
+        $this->_status = (bool) $status;
+
+        return $this;
+    }
+
+    /**
+     * Get the status
+     *
+     * @return boolean
+     */
+    public function getStatus()
+    {
+        return $this->_status;
+    }
+
+    /**
+     * Alias for getStatus()
+     *
+     * @return boolean
+     */
+    public function isValid()
+    {
+        return $this->getStatus();
+    }
+
+    /**
+     * Set the error codes
+     *
+     * @param array $errorCodes
+     * @return Ghost_Service_ReCaptcha2_Response
+     */
+    public function setErrorCodes($errorCodes)
+    {
+        $this->_errorCodes = $errorCodes;
+
+        return $this;
+    }
+
+    /**
+     * Get the error codes
+     *
+     * @return string
+     */
+    public function getErrorCodes()
+    {
+        return $this->_errorCodes;
+    }
+
+    /**
+     * Populate this instance based on a Zend_Http_Response object
+     *
+     * @param Zend_Http_Response $response
+     * @return Zend_Service_ReCaptcha_Response
+     */
+    public function setFromHttpResponse(Zend_Http_Response $response)
+    {
+        $body = Zend_Json::decode($response->getBody());
+
+        // Default status and error code
+        $status = false;
+        $errorCodes = array();
+
+        if (!empty($body['success']) && is_bool($body['success'])) {
+            $status = $body['success'];
+        }
+
+        if (!empty($body['error-codes']) && is_array($body['error-codes'])) {
+            $errorCodes = $body['error-codes'];
+        }
+
+        $this->setStatus($status);
+        $this->setErrorCodes($errorCodes);
+
+        return $this;
+    }
+}

--- a/application/libraries/Omeka/Form.php
+++ b/application/libraries/Omeka/Form.php
@@ -35,6 +35,9 @@ class Omeka_Form extends Zend_Form
     {
         $this->addElementPrefixPath('Omeka_', 'Omeka/');
         $this->addPrefixPath('Omeka_Form_Element', 'Omeka/Form/Element/', 'element');
+        // add paths for reCAPTCHA v2
+        $this->addElementPrefixPath('Ghost_', 'Ghost/');
+        $this->addPrefixPath('Ghost_Form_Decorator', 'Ghost/Form/Decorator', self::DECORATOR);
 
         // set the default element decorators
         $this->setElementDecorators($this->getDefaultElementDecorators());

--- a/application/tests/suite/Omeka/CaptchaTest.php
+++ b/application/tests/suite/Omeka/CaptchaTest.php
@@ -50,4 +50,18 @@ class Omeka_CaptchaTest extends PHPUnit_Framework_TestCase
         $this->assertNotNull($captcha);
         $this->assertInstanceOf('Zend_Captcha_Adapter', $captcha);
     }
+
+    public function testGetCaptchaVersion2()
+    {
+        $options = array(
+            Omeka_Captcha::PUBLIC_KEY_OPTION => 'public_key',
+            Omeka_Captcha::PRIVATE_KEY_OPTION => 'private_key',
+            Omeka_Captcha::VERSION_OPTION => 'v2'
+            );
+        $this->bootstrap->getContainer()->options = $options;
+
+        $captcha = Omeka_Captcha::getCaptcha();
+        $this->assertNotNull($captcha);
+        $this->assertInstanceOf('Ghost_Captcha_ReCaptcha2', $captcha);
+    }
 }


### PR DESCRIPTION
Fixes #730 

New settings added to decide which ReCaptcha version to use. By default the old v1 is used.

Plugins like *Commenting* would need to add conditional captcha adapter switch.
```php
$this->addElement('captcha', 'captcha',  array(
	'label' => __("Please verify you're a human"),
	'captcha' => array(
		'captcha' => get_option(Omeka_Captcha::VERSION_OPTION) == 'v2' ? 'ReCaptcha2' : 'ReCaptcha',
		'pubkey' => get_option('recaptcha_public_key'),
		'privkey' => get_option('recaptcha_private_key'),
		'ssl' => true //make the connection secure so IE8 doesn't complain. if works, should branch around http: vs https:
	)
));
$this->getElement('captcha')->removeDecorator('ViewHelper');
```

Plugins like *Contribute* will work as before.

*TODO*: I see the old URL to http://recaptcha.net is dead so I replaced it with URL to Google's ReCaptcha. But how about replacing Public/Private Key with Site/Secret Key?