### PR TITLE
Placeholder treated as NULL for item-type/collection search criteria

### DIFF
--- a/application/models/Table/Item.php
+++ b/application/models/Table/Item.php
@@ -197,10 +197,11 @@ class Table_Item extends Omeka_Db_Table
             if (is_numeric($collection)) {
                 return (int) $collection;
             }
-            return;
+            return '';
         }, $collections);
 
-        $hasEmpty = in_array(null, $collectionIds);
+        // strict check to skip placeholder (empty string)
+        $hasEmpty = in_array(null, $collectionIds, true);
         $collectionIds = array_filter($collectionIds);
         if (!empty($collectionIds)) {
             $select->joinLeft(
@@ -245,10 +246,11 @@ class Table_Item extends Omeka_Db_Table
             if (is_string($type)) {
                 return $type;
             }
-            return;
+            return '';
         }, $types);
 
-        $hasEmpty = in_array(null, $typeIdsOrNames);
+        // strict check to skip placeholder (empty string)
+        $hasEmpty = in_array(null, $typeIdsOrNames, true);
         $typeIdsOrNames = array_filter($typeIdsOrNames);
         if ($typeIdsOrNames) {
             $select->joinLeft(array(


### PR DESCRIPTION
When un-selecting item-type or collection in advanced item search (by selecting placeholder *Select Below*) the placeholder is treated as NULL and leads to wrong search results.

Note: Calling only `return;` inside `array_map` is treated as `NULL`, which happens with placeholder for collections. Item-type problem is this: `in_array(null, array('')) => true`. So in both cases `$hasEmpty` var is `true`.