### PR TITLE
We should not support Captcha V1. It will soon stop working. Users st…

### DIFF
--- a/application/forms/SecuritySettings.php
+++ b/application/forms/SecuritySettings.php
@@ -65,8 +65,8 @@ class Omeka_Form_SecuritySettings extends Omeka_Form
         $this->addElement('select', Omeka_Captcha::VERSION_OPTION,
             array(
                 'label' => __('ReCaptcha Version'),
-                'description' => __('Choose which ReCaptcha version you\'re using. If you\'re using keys for ReCaptcha v1, please consider %s to v2, before March 31, 2018', 
-                        '<a href="https://developers.google.com/recaptcha/docs/faq" target="_blank">upgrading</a>'),
+                'description' => __('Choose which ReCaptcha version you\'re using. If you\'re using keys for ReCaptcha v1, please consider upgrading to v2, before March 31, 2018: %s', 
+                        '<a href="https://developers.google.com/recaptcha/docs/faq" target="_blank">https://developers.google.com/recaptcha/docs/faq</a>'),
                 'value' => get_option(Omeka_Captcha::VERSION_OPTION) ?: 'v2',
                 'multiOptions' => array('v2' => 'ReCaptcha v2')
             )

--- a/application/forms/SecuritySettings.php
+++ b/application/forms/SecuritySettings.php
@@ -65,9 +65,10 @@ class Omeka_Form_SecuritySettings extends Omeka_Form
         $this->addElement('select', Omeka_Captcha::VERSION_OPTION,
             array(
                 'label' => __('ReCaptcha Version'),
-                'description' => __('Choose which ReCaptcha version you\'re using. Note that ReCaptcha v1 is deprecated and will not work after March 31, 2018.'),
-                'value' => get_option(Omeka_Captcha::VERSION_OPTION) ?: '',
-                'multiOptions' => array('' => 'ReCaptcha v1', 'v2' => 'ReCaptcha v2')
+                'description' => __('Choose which ReCaptcha version you\'re using. If you\'re using keys for ReCaptcha v1, please consider upgrading to v2, before March 31, 2018', 
+                        'https://developers.google.com/recaptcha/docs/faq'),
+                'value' => get_option(Omeka_Captcha::VERSION_OPTION) ?: 'v2',
+                'multiOptions' => array('v2' => 'ReCaptcha v2')
             )
         );
 

--- a/application/forms/SecuritySettings.php
+++ b/application/forms/SecuritySettings.php
@@ -65,8 +65,8 @@ class Omeka_Form_SecuritySettings extends Omeka_Form
         $this->addElement('select', Omeka_Captcha::VERSION_OPTION,
             array(
                 'label' => __('ReCaptcha Version'),
-                'description' => __('Choose which ReCaptcha version you\'re using. If you\'re using keys for ReCaptcha v1, please consider upgrading to v2, before March 31, 2018', 
-                        'https://developers.google.com/recaptcha/docs/faq'),
+                'description' => __('Choose which ReCaptcha version you\'re using. If you\'re using keys for ReCaptcha v1, please consider %s to v2, before March 31, 2018', 
+                        '<a href="https://developers.google.com/recaptcha/docs/faq" target="_blank">upgrading</a>'),
                 'value' => get_option(Omeka_Captcha::VERSION_OPTION) ?: 'v2',
                 'multiOptions' => array('v2' => 'ReCaptcha v2')
             )

--- a/application/libraries/Omeka/Captcha.php
+++ b/application/libraries/Omeka/Captcha.php
@@ -43,17 +43,13 @@ class Omeka_Captcha
                 ));
                 break;
 
-            default:
-                // old, deprecated ReCaptcha v1 shipped with ZF
-                $ssl = false;
-                if ($request = Zend_Controller_Front::getInstance()->getRequest()) {
-                    $ssl = $request->isSecure();
-                }
-
-                $captcha = new Zend_Captcha_ReCaptcha(array(
-                    'pubKey' => $publicKey,
-                    'privKey' => $privateKey,
-                    'ssl' => $ssl));
+            default:                
+                /*We should not use or support old reCaptcha. Any calls to the v1 API will not work after March 31, 2018
+                source: https://developers.google.com/recaptcha/docs/faq*/
+                $captcha = new Ghost_Captcha_ReCaptcha2(array(
+                'pubKey' => $publicKey,
+                'privKey' => $privateKey,
+                ));
                 break;
         }
 


### PR DESCRIPTION
We should not support Captcha V1. It will soon stop working. Users still on V1 will need to upgrade their keys. V1 keys *might* still work/migrate to V2 after March 31, 2018:
https://groups.google.com/forum/#!topic/recaptcha/Cd0vT0azu-c

V2 is set as default in my code, V1 removed from selection.