### PR TITLE
Allow plugins to inject HTMLPurifier config/definitions

### DIFF
--- a/application/libraries/Omeka/Filter/HtmlPurifier.php
+++ b/application/libraries/Omeka/Filter/HtmlPurifier.php
@@ -143,11 +143,11 @@ class Omeka_Filter_HtmlPurifier implements Zend_Filter_Interface
         $purifierConfig->set('HTML.AllowedAttributes', $allowedHtmlAttributes);
 
         // allow plugins to inject HTMLPurifier config/definitions
-        $purifierConfig = apply_filters('html_purifier_config_setup', $purifierConfig, [
+        $purifierConfig = apply_filters('html_purifier_config_setup', $purifierConfig, array(
             'defaults' => self::$_purifierConfig,
             'allowedHtmlElements' => $allowedHtmlElements,
             'allowedHtmlAttributes' => $allowedHtmlAttributes
-        ]);
+        ));
 
         $purifier = HTMLPurifier::instance($purifierConfig);
         return $purifier;

--- a/application/libraries/Omeka/Filter/HtmlPurifier.php
+++ b/application/libraries/Omeka/Filter/HtmlPurifier.php
@@ -142,6 +142,13 @@ class Omeka_Filter_HtmlPurifier implements Zend_Filter_Interface
         $purifierConfig->set('HTML.AllowedElements', $allowedHtmlElements);
         $purifierConfig->set('HTML.AllowedAttributes', $allowedHtmlAttributes);
 
+        // allow plugins to inject HTMLPurifier config/definitions
+        $purifierConfig = apply_filters('html_purifier_config_setup', $purifierConfig, [
+            'defaults' => self::$_purifierConfig,
+            'allowedHtmlElements' => $allowedHtmlElements,
+            'allowedHtmlAttributes' => $allowedHtmlAttributes
+        ]);
+
         $purifier = HTMLPurifier::instance($purifierConfig);
         return $purifier;
     }


### PR DESCRIPTION
As mentioned in [forum](https://forum.omeka.org/t/best-way-to-extend-htmlpurifier-definitions/6399) if one plugin reads/get values or definitions, the object gets finalized so it's impossible to write/set more values to it later. So other plugins must use `$configCopy = HTMLPurifier_Config::inherit($currentConfig);` 
That is also reason why I included the defaults and allowed elements and attributes as filter arguments (no need to get definitions in order to find out what are the current allowed elements)

Feel free to propose different filter name, perhaps shorter: `html_purifier_config` is sufficient?