### PR TITLE
Fixed a deprecation notice in Zend libraries for full compatibility with php 7.2.

### DIFF
--- a/application/libraries/Zend/Cache/Backend.php
+++ b/application/libraries/Zend/Cache/Backend.php
@@ -76,7 +76,7 @@ class Zend_Cache_Backend
     public function setDirectives($directives)
     {
         if (!is_array($directives)) Zend_Cache::throwException('Directives parameter must be an array');
-        while (list($name, $value) = each($directives)) {
+        foreach ($directives as $name => $value) {
             if (!is_string($name)) {
                 Zend_Cache::throwException("Incorrect option name : $name");
             }


### PR DESCRIPTION
Because the issue is in the cache, it is used anywhere and it breaks some plugins and, in particular, the queries that return a json.