### PR TITLE
Remove unrelated elements when changing item type

### DIFF
--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -170,6 +170,31 @@ class Item extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
     }
 
     /**
+     * Get a complete set of Element IDs associated with this Item.
+     *
+     * @uses Mixin_ElementText::getElementsBySetName()
+     * @uses Table_Element::findByItemType()
+     * @return array Element IDs that are associated with the item type of
+     * the item together with Dublin Core element set.
+     */
+    public function getAssociatedElementIds()
+    {
+        $elementIds = array();
+        $dublinCoreElements = $this->getElementsBySetName('Dublin Core');
+        foreach ($dublinCoreElements as $element) {
+            $elementIds[] = $element->id;
+        }
+        if ($this->item_type_id) {
+            $itemTypeElements = $this->ItemTypeElements;
+            foreach ($itemTypeElements as $element) {
+                $elementIds[] = $element->id;
+            }
+        }
+
+        return $elementIds;
+    }
+
+    /**
      * Get a property for display.
      *
      * @param string $property


### PR DESCRIPTION
This partially solves situation, where changing item type of an item keeps already filled information in elements **not associated** with new item type.
The problem is mostly apparent when searching, because all existing element texts are indexed, but not visible in show pages.

There's still issue when removing element association for specific item type and when removing element completely from Omeka. But it's less common case and users can be prompted to reindex search.