### PR TITLE
Added a .htaccess rule to forbid access to dot files, for example .git/logs/HEAD.

### DIFF
--- a/.htaccess.changeme
+++ b/.htaccess.changeme
@@ -19,6 +19,9 @@
 
 RewriteEngine on
 
+# Forbid access to all dot files, except well-known.
+RewriteRule (?:^|/)\.(?!well-known(?:/.*)?$) - [F,NC]
+
 # If you know mod_rewrite is enabled, but you are still getting mod_rewrite
 # errors, uncomment the line below and replace "/" with your base directory.
 #


### PR DESCRIPTION
When the site is managed via git, that is common, the .git is generally in the same directory, so anybody can access anything in the hidden files of the site. This commit fixes it.