### PR TITLE
Skip empty arrays when creating IN() condition

### DIFF
--- a/application/libraries/Omeka/Db/Table.php
+++ b/application/libraries/Omeka/Db/Table.php
@@ -366,6 +366,10 @@ class Omeka_Db_Table
         foreach ($columns as $column) {
             if (array_key_exists($column, $params)) {
                 if (is_array($params[$column])) {
+                    // empty IN() breaks SQL
+                    if (empty($params[$column])) {
+                        continue;
+                    }
                     $select->where("`$alias`.`$column` IN (?)", $params[$column]);
                 } else {
                     $select->where("`$alias`.`$column` = ?", $params[$column]);


### PR DESCRIPTION
Without this, I need to always check if the array parameter is empty and remove it prior calling `getSelectForFindBy()`. 