### PR TITLE
Added removal of tag to deleteTags function

### DIFF
--- a/application/models/Mixin/Tag.php
+++ b/application/models/Mixin/Tag.php
@@ -132,6 +132,7 @@ class Mixin_Tag extends Omeka_Record_Mixin_AbstractMixin
 
         $findWith['tag'] = $tags;
         $findWith['record'] = $this->_record;
+		$db = $this->_record->getDb();
 
         $taggings = $this->_joinTable->findBy($findWith);
         $removed = array();
@@ -139,6 +140,14 @@ class Mixin_Tag extends Omeka_Record_Mixin_AbstractMixin
             $removed[] = $this->_tagTable->find($tagging->tag_id);
             $tagging->delete();
         }
+        		
+		foreach ($tags as $tag) {
+			$count = $this->_joinTable->count(array('tag' => $tag));
+			if ($count == 0) {
+				$db->delete($db->Tags, array('name = ?' => $tag));
+			}
+		}
+
 
         $nameForHook = strtolower($this->_type);
         fire_plugin_hook("remove_{$nameForHook}_tag", array('record' => $this->_record, 'removed' => $removed));


### PR DESCRIPTION
Function would delete taggings, but not the tag, even when there were no more references to that tag in whole database. Now, when removing a tag from item, if there are no more references to that tag it will be deleted.