### PR TITLE
fix markup in admin/users/edit page

### DIFF
--- a/application/languages/ru.po
+++ b/application/languages/ru.po
@@ -3107,7 +3107,7 @@ msgid ""
 "Roles describe the permissions a user has. See <a "
 "href='http://omeka.org/codex/User_Roles' target='_blank'>documentation</a> "
 "for details."
-msgstr "Роли описывают разрешения, которые имеет пользователь. См. <a href='http://omeka.org/codex/User_Roles' target='_blank'> документацию</ A> для дальнейших подробностей."
+msgstr "Роли описывают разрешения, которые имеет пользователь. См. <a href='http://omeka.org/codex/User_Roles' target='_blank'> документацию</a> для дальнейших подробностей."
 
 #: application/forms/User.php:137
 msgid "Inactive users cannot log in to the site."


### PR DESCRIPTION
Fix incorrect markup that causes problem with user role select. Wrapped a element doesn't let change user role in russian localization.