### PR TITLE
Default fallback image now modifiable via add_file_fallback_image fun…

### DIFF
--- a/application/views/helpers/FileMarkup.php
+++ b/application/views/helpers/FileMarkup.php
@@ -157,14 +157,8 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
         'audio' => 'fallback-audio.png',
         'image' => 'fallback-image.png',
         'video' => 'fallback-video.png',
+        'generic' => 'fallback-file.png', // Fallback image used when no other fallbacks are appropriate.
     );
-
-    /**
-     * Fallback image used when no other fallbacks are appropriate.
-     *
-     * @var string
-     */
-    const GENERIC_FALLBACK_IMAGE = 'fallback-file.png';
 
     /**
      * Add MIME types and/or file extensions and associated callbacks to the 
@@ -657,7 +651,7 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
             return self::$_fallbackImages[$mimePrefix];
         }
 
-        return self::GENERIC_FALLBACK_IMAGE;
+        return self::$_fallbackImages['generic'];
     }
 
     /**

--- a/application/views/helpers/FileMarkup.php
+++ b/application/views/helpers/FileMarkup.php
@@ -145,8 +145,15 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
             'linkAttributes' => array(),
             'imgAttributes' => array(),
             'filenameAttributes' => array()
-            )
-        );
+        )
+    );
+
+    /**
+     * Fallback image used when no other fallbacks are appropriate.
+     *
+     * @var string
+     */
+    const GENERIC_FALLBACK_IMAGE = 'fallback-file.png';
 
     /**
      * Images to show when a file has no derivative.
@@ -157,7 +164,7 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
         'audio' => 'fallback-audio.png',
         'image' => 'fallback-image.png',
         'video' => 'fallback-video.png',
-        'generic' => 'fallback-file.png', // Fallback image used when no other fallbacks are appropriate.
+        '*'     => GENERIC_FALLBACK_IMAGE
     );
 
     /**
@@ -651,7 +658,7 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
             return self::$_fallbackImages[$mimePrefix];
         }
 
-        return self::$_fallbackImages['generic'];
+        return self::$_fallbackImages['*'];
     }
 
     /**

--- a/application/views/helpers/FileMarkup.php
+++ b/application/views/helpers/FileMarkup.php
@@ -23,6 +23,13 @@
 class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
 {
     /**
+     * Fallback image used when no other fallbacks are appropriate.
+     *
+     * @var string
+     */
+    const GENERIC_FALLBACK_IMAGE = 'fallback-file.png';
+
+    /**
      * Array of MIME types and the callbacks that can process it.
      *
      * Example:
@@ -149,13 +156,6 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
     );
 
     /**
-     * Fallback image used when no other fallbacks are appropriate.
-     *
-     * @var string
-     */
-    const GENERIC_FALLBACK_IMAGE = 'fallback-file.png';
-
-    /**
      * Images to show when a file has no derivative.
      *
      * @var array
@@ -164,7 +164,7 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
         'audio' => 'fallback-audio.png',
         'image' => 'fallback-image.png',
         'video' => 'fallback-video.png',
-        '*'     => GENERIC_FALLBACK_IMAGE
+        '*'     => self::GENERIC_FALLBACK_IMAGE
     );
 
     /**


### PR DESCRIPTION
See https://github.com/omeka/Omeka/issues/913

Default fallback image was not programmaticaly modifiable because of it using a constant; I've solved the problem by creating a new entry for the $_fallbackImages array.