### PR TITLE
Fixes problem with collection's image

### DIFF
--- a/application/models/Collection.php
+++ b/application/models/Collection.php
@@ -225,10 +225,19 @@ class Collection extends Omeka_Record_AbstractRecord implements Zend_Acl_Resourc
             'sort_field' => 'featured',
             'sort_dir' => 'd'
         ), 1);
-        if ($itemArray) {
-            return ($itemArray[0]->getFile());
-        } else {
-            return null;
-        }
-    }
+	if ($itemArray) {
+		return ($itemArray[0]->getFile());
+	} else {
+		// In case no Item with an image was found
+		$itemArray = $itemTable->findBy(array(
+			'collection' => $this->id,
+			'sort_field' => 'featured',
+			'sort_dir' => 'd'
+		), 1);
+		if ($itemArray) {
+			return ($itemArray[0]->getFile());
+		} else {
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
It seems that, when a Collection contains no Item with an image (because that Item's image was not generated, and Item is resorting to fallback image when shown), then the Collection itself does not show any image, not even the fallback one.
This fix solves the problem: if no Item with an image is found, than function tries to find any Item and, in absence of an image, the fallback one will be used for the Collection too. Sort field and direction are mantained, as a featured Item could exist even if it didn't have an image.