### PR TITLE
Fixed numeric html attributes being discarded

### DIFF
--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -1486,6 +1486,7 @@ function tag_attributes($attributes)
         if (preg_match('/[^A-Za-z0-9_:.-]/', $key)) {
             continue;
         }
+        if (is_numeric($attribute)) $attribute = "$attribute";
         if (is_string($attribute)) {
             $attr[$key] = $key . '="' . html_escape($attribute) . '"';
         } elseif ($attribute === true) {


### PR DESCRIPTION
I've just encountered this bug, I don't know if there's a bug report about it.

Before this change, `tag_attributes()` would silently discard all attributes with numeric values unless the values were passed as string.
For example:
```
tag_attributes(['width'=>300, 'height'=>200, 'foo'=>'bar'];
// expected result: 'width="300" height="200" foo="bar"'
// actual result before fix: 'foo="bar"'

tag_attributes(['width'=>'300', 'height'=>'200', 'foo'=>'bar'];  // this would already work as expected
```

As a consequence:
```
record_image($someRecord, null, ['width'=>300, 'height'=>200]);
```
would result in an image tag without the expected width and height attributes.