### PR TITLE
Catch general errors during record->save() in re-indexing

### DIFF
--- a/application/models/Job/SearchTextIndex.php
+++ b/application/models/Job/SearchTextIndex.php
@@ -46,7 +46,7 @@ class Job_SearchTextIndex extends Omeka_Job_AbstractJob
                     // Save the record object, which indexes its search text.
                     try {
                         $recordObject->save();
-                    } catch (Omeka_Validate_Exception $e) {
+                    } catch (Exception $e) {
                         _log($e, Zend_Log::ERR);
                         _log(sprintf('Failed to index %s #%s',
                                 get_class($recordObject), $recordObject->id),


### PR DESCRIPTION
Running into an issue on a current site where the re-indexing process fails out on totally unrelated after-save hooks. It seems to me like this job should be pretty generous in terms of continuing on to process items regardless of whatever exceptions are thrown, so proposing to update this to catch all Exceptions, not just Validation exceptions.