### PR TITLE
Improved tags handling, collections browsing, dashboard

### DIFF
--- a/admin/themes/default/collections/browse.php
+++ b/admin/themes/default/collections/browse.php
@@ -1,9 +1,10 @@
 <?php
+queue_js_file('collections-browse');
 $pageTitle = __('Browse Collections') . ' ' .  __('(%s total)', $total_results);
 $totalItemsWithoutCollection = get_db()->getTable('Item')->count(array('collection' => 0));
 echo head(array('title'=>$pageTitle, 'bodyclass'=>'collections'));
 echo flash();
-echo item_search_filters();
+echo collection_search_filters();
 ?>
 
 <?php if (total_records('Collection') > 0): ?>
@@ -13,7 +14,7 @@ echo item_search_filters();
             <?php echo __('Add a Collection'); ?>
         </a>
     <?php endif; ?>
-    <?php echo common('quick-filters', array(), 'collections'); ?>
+	<?php echo common('quick-filters', array(), 'collections'); ?>
     <p class="not-in-collections">
     <?php if ($totalItemsWithoutCollection):
         $withoutCollectionMessage = __(plural('%s%d item%s has no collection.', "%s%d items%s aren't in a collection.",
@@ -48,13 +49,25 @@ echo item_search_filters();
                         <?php endif; ?>
                         <?php echo link_to_collection(); ?>
                         <?php if (!$collection->public) echo __('(Private)'); ?>
+                        <?php if (is_allowed($collection, 'edit')): ?>
                         <ul class="action-links">
                             <li><?php echo link_to_collection(__('Edit'), array('class'=>'edit'), 'edit'); ?></li>
-							<?php if (is_allowed($collection, 'delete')): ?>
-								<li><?php echo link_to_collection(__('Delete'), array('class' => 'delete-confirm'), 'delete-confirm'); ?></li>
-							<?php endif; ?>
+                            <?php if (is_allowed($collection, 'delete')): ?>
+                                <li><?php echo link_to_collection(__('Delete'), array('class' => 'delete-confirm'), 'delete-confirm'); ?></li>
+                            <?php endif; ?>
                         </ul>
+                        <?php endif; ?>
                         <?php fire_plugin_hook('admin_collections_browse_each', array('collection' => $collection, 'view' => $this)); ?>
+                        <div class="details">
+                            <p>
+                                <strong><?php echo __('Description'); ?>:</strong>
+                                <?php echo snippet_by_word_count(metadata('collection', array('Dublin Core', 'Description')), 40); ?>
+                            </p>
+                            <p>
+                                <strong><?php echo __('Subject'); ?>:</strong>
+                                <?php echo metadata('collection', array('Dublin Core', 'Subject'), array('all'=>true, 'delimiter'=>' | ')); ?>
+                            </p>
+                        </div>
                     </td>
                     <td>
                         <?php if ($collection->hasContributor()): ?>
@@ -78,7 +91,17 @@ echo item_search_filters();
         <?php if (is_allowed('Collections', 'add')): ?>
             <a href="<?php echo html_escape(url('collections/add')); ?>" class="small green button"><?php echo __('Add a Collection'); ?></a>
         <?php endif; ?>
+		<?php echo common('quick-filters', array(), 'collections'); ?>
         <p class="not-in-collections"><?php echo $withoutCollectionMessage; ?></p>
+
+    <script type="text/javascript">
+    Omeka.addReadyCallback(Omeka.CollectionsBrowse.setupDetails, [
+        <?php echo js_escape(__('Details')); ?>,
+        <?php echo js_escape(__('Show Details')); ?>,
+        <?php echo js_escape(__('Hide Details')); ?>
+    ]);
+    </script>
+
     <?php else: ?>
         <p><?php echo __('There are no collections on this page.'); ?> <?php echo link_to('collections', null, __('View All Collections')); ?></p>
     <?php endif; ?>

--- a/admin/themes/default/collections/browse.php
+++ b/admin/themes/default/collections/browse.php
@@ -3,6 +3,7 @@ $pageTitle = __('Browse Collections') . ' ' .  __('(%s total)', $total_results);
 $totalItemsWithoutCollection = get_db()->getTable('Item')->count(array('collection' => 0));
 echo head(array('title'=>$pageTitle, 'bodyclass'=>'collections'));
 echo flash();
+echo item_search_filters();
 ?>
 
 <?php if (total_records('Collection') > 0): ?>
@@ -12,6 +13,7 @@ echo flash();
             <?php echo __('Add a Collection'); ?>
         </a>
     <?php endif; ?>
+    <?php echo common('quick-filters', array(), 'collections'); ?>
     <p class="not-in-collections">
     <?php if ($totalItemsWithoutCollection):
         $withoutCollectionMessage = __(plural('%s%d item%s has no collection.', "%s%d items%s aren't in a collection.",

--- a/admin/themes/default/collections/browse.php
+++ b/admin/themes/default/collections/browse.php
@@ -46,11 +46,12 @@ echo flash();
                         <?php endif; ?>
                         <?php echo link_to_collection(); ?>
                         <?php if (!$collection->public) echo __('(Private)'); ?>
-                        <?php if (is_allowed($collection, 'edit')): ?>
                         <ul class="action-links">
                             <li><?php echo link_to_collection(__('Edit'), array('class'=>'edit'), 'edit'); ?></li>
+							<?php if (is_allowed($collection, 'delete')): ?>
+								<li><?php echo link_to_collection(__('Delete'), array('class' => 'delete-confirm'), 'delete-confirm'); ?></li>
+							<?php endif; ?>
                         </ul>
-                        <?php endif; ?>
                         <?php fire_plugin_hook('admin_collections_browse_each', array('collection' => $collection, 'view' => $this)); ?>
                     </td>
                     <td>

--- a/admin/themes/default/collections/quick-filters.php
+++ b/admin/themes/default/collections/quick-filters.php
@@ -1,0 +1,11 @@
+<ul class="quick-filter-wrapper">
+    <li><a href="#"><?php echo __('Quick Filter'); ?></a>
+    <ul class="dropdown">
+        <li><span class="quick-filter-heading"><?php echo __('Quick Filter') ?></span></li>
+        <li><a href="<?php echo url('collections/browse'); ?>"><?php echo __('View All') ?></a></li>
+        <li><a href="<?php echo url('collections/browse', array('public' => 1)); ?>"><?php echo __('Public'); ?></a></li>
+        <li><a href="<?php echo url('collections/browse', array('public' => 0)); ?>"><?php echo __('Private'); ?></a></li>
+        <li><a href="<?php echo url('collections/browse', array('featured' => 1)); ?>"><?php echo __('Featured'); ?></a></li>
+    </ul>
+    </li>
+</ul>

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -246,7 +246,7 @@ img { border: 0; }
         font-family: monospace;
     }
 
-    input[type=text], input[type=password], input[type=email] { {
+    input[type=text], input[type=password], input[type=email] {
         height: 30px;
         border: 1px solid #d8d8d8;
         -webkit-border-radius: 0;

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -304,7 +304,7 @@ img { border: 0; }
         }
 
 
-        .inputs input[type=text], .inputs input[type=password], .inputs textarea {
+        .inputs input[type=text], .inputs input[type=password], .inputs input[type=email], .inputs textarea {
             width: 100%;
             -webkit-box-sizing: border-box;
             -moz-box-sizing: border-box;

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -246,7 +246,7 @@ img { border: 0; }
         font-family: monospace;
     }
 
-    input[type=text], input[type=password] {
+    input[type=text], input[type=password], input[type=email] { {
         height: 30px;
         border: 1px solid #d8d8d8;
         -webkit-border-radius: 0;

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -1547,14 +1547,14 @@ header nav {
     margin-bottom: 20px;
 }
 
- #item-filters ul {
+ #item-filters ul, #collection-filters ul {
     clear: both;
     list-style-type: none;
     padding: 0;
     margin: 0;
 }
 
-    #item-filters li {
+    #item-filters li, #collection-filters li {
         display: inline-block;
         background: url('../images/search.png') no-repeat;
         padding: 0 0 0 21px;

--- a/admin/themes/default/index.php
+++ b/admin/themes/default/index.php
@@ -74,7 +74,7 @@ endif; ?>
     foreach (loop('collections') as $collection):
 ?>
     <div class="recent-row">
-        <p class="recent"><?php echo link_to_collection(); ?></p>
+        <p class="recent"><?php echo link_to_collection() . " (" . metadata($collection, 'total_items') . ")"; ?></p>
         <?php if (is_allowed($collection, 'edit')): ?>
         <p class="dash-edit"><?php echo link_to_collection(__('Edit'), array(), 'edit'); ?></p>
         <?php endif; ?>

--- a/admin/themes/default/index.php
+++ b/admin/themes/default/index.php
@@ -51,7 +51,7 @@ endif; ?>
 <?php ob_start(); ?>
 <h2><?php echo __('Recent Items'); ?></h2>
 <?php
-    set_loop_records('items', get_recent_items(5));
+    set_loop_records('items', get_recent_items(get_option('recent_admin')));
     foreach (loop('items') as $item):
 ?>
     <div class="recent-row">
@@ -69,7 +69,7 @@ endif; ?>
 <?php ob_start(); ?>
 <h2><?php echo __('Recent Collections'); ?></h2>
 <?php
-    $collections = get_recent_collections(5);
+    $collections = get_recent_collections(get_option('recent_admin'));
     set_loop_records('collections', $collections);
     foreach (loop('collections') as $collection):
 ?>

--- a/admin/themes/default/items/batch-edit.php
+++ b/admin/themes/default/items/batch-edit.php
@@ -1,4 +1,6 @@
 <?php
+queue_js_file('items');
+$tagDelimiter = get_option('tag_delimiter');
 $title = __('Batch Edit Items');
 if (!$isPartial):
     echo head(
@@ -12,6 +14,14 @@ endif;
 <div title="<?php echo $title; ?>">
 
 <form id="batch-edit-form" action="<?php echo html_escape(url('items/batch-edit-save')); ?>" method="post" accept-charset="utf-8">
+    <script type="text/javascript">
+    //<![CDATA[
+    jQuery(document).ready(function () {
+        Omeka.Items.tagDelimiter = <?php echo js_escape($tagDelimiter); ?>;
+        Omeka.Items.tagChoices('#metadata-tags', <?php echo js_escape(url(array('controller' => 'tags', 'action' => 'autocomplete'), 'default', array(), true)); ?>);
+    });
+    //]]>
+    </script>
     <section class="seven columns alpha">
         <fieldset id="item-list" class="panel">
             <h2 class="two columns alpha"><?php echo __('Items'); ?></h2>

--- a/admin/themes/default/javascripts/collections-browse.js
+++ b/admin/themes/default/javascripts/collections-browse.js
@@ -20,7 +20,7 @@ Omeka.CollectionsBrowse = {};
 
         var toggleList = '<a href="#" class="toggle-all-details small blue button">' + showDetailsText + '</a>';
 
-        $('.advanced-search-link').before(toggleList);
+        $('.quick-filter-wrapper').before(toggleList);
 
         // Toggle collection details.
         var detailsShown = false;

--- a/admin/themes/default/javascripts/collections-browse.js
+++ b/admin/themes/default/javascripts/collections-browse.js
@@ -1,0 +1,39 @@
+if (!Omeka) {
+    var Omeka = {};
+}
+
+Omeka.CollectionsBrowse = {};
+
+(function ($) {
+    Omeka.CollectionsBrowse.setupDetails = function (detailsText, showDetailsText, hideDetailsText) {
+        $('.details').hide();
+        $('.action-links').prepend('<li class="details-link">' + detailsText + '</li> ');
+
+        $('tr.collection').each(function() {
+            var collectionDetails = $(this).find('.details');
+            if ($.trim(collectionDetails.html()) != '') {
+                $(this).find('.details-link').css({'color': '#4E7181', 'cursor': 'pointer'}).click(function() {
+                    collectionDetails.slideToggle('fast');
+                });
+            }
+        });
+
+        var toggleList = '<a href="#" class="toggle-all-details small blue button">' + showDetailsText + '</a>';
+
+        $('.advanced-search-link').before(toggleList);
+
+        // Toggle collection details.
+        var detailsShown = false;
+        $('.toggle-all-details').click(function (e) {
+            e.preventDefault();
+            if (detailsShown) {
+            	$('.toggle-all-details').text(showDetailsText);
+            	$('.details').slideUp('fast');
+            } else {
+            	$('.toggle-all-details').text(hideDetailsText);
+            	$('.details').slideDown('fast');
+            }
+            detailsShown = !detailsShown;
+        });
+    };
+})(jQuery);

--- a/application/controllers/AppearanceController.php
+++ b/application/controllers/AppearanceController.php
@@ -14,6 +14,7 @@ class AppearanceController extends Omeka_Controller_AbstractActionController
     const DEFAULT_FULLSIZE_CONSTRAINT = 800;
     const DEFAULT_THUMBNAIL_CONSTRAINT = 200;
     const DEFAULT_SQUARE_THUMBNAIL_CONSTRAINT = 200;
+    const DEFAULT_RECENT_ADMIN = 5;
     const DEFAULT_PER_PAGE_ADMIN = 10;
     const DEFAULT_PER_PAGE_PUBLIC = 10;
 

--- a/application/forms/AppearanceSettings.php
+++ b/application/forms/AppearanceSettings.php
@@ -46,7 +46,7 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
 
         $this->addElement('text', 'recent_admin', array(
             'label' => __('Recents Items/Collections (admin)'),
-            'description' => __('Limit the number of recent Items and Collections displayed in the administrative inteface dashboard.'),
+            'description' => __('Limit the number of recent Items and Collections displayed in the administrative inteface.'),
             'validators' => array('Digits'),
             'required' => true,
         ));

--- a/application/forms/AppearanceSettings.php
+++ b/application/forms/AppearanceSettings.php
@@ -44,6 +44,13 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
             'required' => true,
         ));
 
+        $this->addElement('text', 'recent_admin', array(
+            'label' => __('Recents Items/Collections (admin)'),
+            'description' => __('Limit the number of recent Items and Collections displayed in the administrative inteface dashboard.'),
+            'validators' => array('Digits'),
+            'required' => true,
+        ));
+
         $this->addElement('text', 'per_page_admin', array(
             'label' => __('Results Per Page (admin)'),
             'description' => __('Limit the number of results displayed per page in the administrative interface.'),
@@ -99,7 +106,7 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
 
         $this->addDisplayGroup(
             array(
-                'use_square_thumbnail', 'link_to_file_metadata', 'per_page_admin', 'per_page_public',
+                'use_square_thumbnail', 'link_to_file_metadata', 'recent_admin', 'per_page_admin', 'per_page_public',
                 'show_empty_elements', 'show_element_set_headings',
             ),
             'display-settings', array('legend' => __('Display Settings'))

--- a/application/forms/Install.php
+++ b/application/forms/Install.php
@@ -15,6 +15,7 @@ class Omeka_Form_Install extends Omeka_Form
     const DEFAULT_FULLSIZE_CONSTRAINT = 800;
     const DEFAULT_THUMBNAIL_CONSTRAINT = 200;
     const DEFAULT_SQUARE_THUMBNAIL_CONSTRAINT = 200;
+    const DEFAULT_RECENT_ADMIN = 5;
     const DEFAULT_PER_PAGE_ADMIN = 10;
     const DEFAULT_PER_PAGE_PUBLIC = 10;
     const DEFAULT_SHOW_EMPTY_ELEMENTS = false;
@@ -148,6 +149,14 @@ class Omeka_Form_Install extends Omeka_Form
             'required' => true
         ));
 
+        $this->addElement('text', 'recent_admin', array(
+            'label' => __('Recent Items/Collections (admin)'),
+            'description' => __('Limit the number of recent Items and Collections displayed in the administrative inteface.'),
+            'value' => self::DEFAULT_RECENT_ADMIN,
+            'validators' => array('Digits'),
+            'required' => true
+        ));
+
         $this->addElement('text', 'per_page_admin', array(
             'label' => __('Items Per Page (admin)'),
             'description' => __('Limit the number of items displayed per page in the administrative interface.'),
@@ -190,8 +199,8 @@ class Omeka_Form_Install extends Omeka_Form
             array('administrator_email', 'site_title', 'description',
                   'copyright', 'author', 'tag_delimiter', 'fullsize_constraint',
                   'thumbnail_constraint', 'square_thumbnail_constraint',
-                  'per_page_admin', 'per_page_public', 'show_empty_elements',
-                  'path_to_convert'),
+                  'recent_admin', 'per_page_admin', 'per_page_public', 
+                  'show_empty_elements', 'path_to_convert'),
             'site_settings',
             array('legend' => __('Site Settings'))
         );

--- a/application/libraries/globals.php
+++ b/application/libraries/globals.php
@@ -2024,6 +2024,19 @@ function item_search_filters(array $params = null)
 }
 
 /**
+ * Get a list of the current search collection filters in use.
+ *
+ * @package Omeka\Function\Search
+ * @uses Omeka_View_Helper_SearchFilters::searchFilters()
+ * @params array $params Params to override the ones read from the request.
+ * @return string
+ */
+function collection_search_filters(array $params = null)
+{
+    return get_view()->collectionSearchFilters($params);
+}
+
+/**
  * Get metadata for a record.
  *
  * @package Omeka\Function\View

--- a/application/models/Installer/Default.php
+++ b/application/models/Installer/Default.php
@@ -106,6 +106,7 @@ class Installer_Default implements Installer_InstallerInterface
             'thumbnail_constraint' => $this->_getValue('thumbnail_constraint'),
             'square_thumbnail_constraint' => $this->_getValue('square_thumbnail_constraint'),
             'fullsize_constraint' => $this->_getValue('fullsize_constraint'),
+            'recent_admin' => $this->_getValue('recent_admin'),
             'per_page_admin' => $this->_getValue('per_page_admin'),
             'per_page_public' => $this->_getValue('per_page_public'),
             'show_empty_elements' => $this->_getValue('show_empty_elements'),

--- a/application/models/Installer/Task/Options.php
+++ b/application/models/Installer/Task/Options.php
@@ -22,6 +22,7 @@ class Installer_Task_Options implements Installer_TaskInterface
         'thumbnail_constraint',
         'square_thumbnail_constraint',
         'fullsize_constraint',
+        'recent_admin',
         'per_page_admin',
         'per_page_public',
         'show_empty_elements',

--- a/application/models/Installer/Test.php
+++ b/application/models/Installer/Test.php
@@ -24,6 +24,7 @@ class Installer_Test extends Installer_Default
         'thumbnail_constraint' => Omeka_Form_Install::DEFAULT_THUMBNAIL_CONSTRAINT,
         'square_thumbnail_constraint' => Omeka_Form_Install::DEFAULT_SQUARE_THUMBNAIL_CONSTRAINT,
         'fullsize_constraint' => Omeka_Form_Install::DEFAULT_FULLSIZE_CONSTRAINT,
+        'recent_admin' => Omeka_Form_Install::DEFAULT_RECENT_ADMIN,
         'per_page_admin' => Omeka_Form_Install::DEFAULT_PER_PAGE_ADMIN,
         'per_page_public' => Omeka_Form_Install::DEFAULT_PER_PAGE_PUBLIC,
         'show_empty_elements' => Omeka_Form_Install::DEFAULT_SHOW_EMPTY_ELEMENTS,

--- a/application/models/Mixin/Tag.php
+++ b/application/models/Mixin/Tag.php
@@ -139,6 +139,14 @@ class Mixin_Tag extends Omeka_Record_Mixin_AbstractMixin
             $removed[] = $this->_tagTable->find($tagging->tag_id);
             $tagging->delete();
         }
+        
+        $db = $this->_record->getDb();
+		foreach ($tags as $tag) {
+			$count = $this->_joinTable->count(array('tag' => $tag));
+			if ($count == 0) {
+				$db->delete($db->Tags, array('name = ?' => $tag));
+			}
+		}
 
         $nameForHook = strtolower($this->_type);
         fire_plugin_hook("remove_{$nameForHook}_tag", array('record' => $this->_record, 'removed' => $removed));

--- a/application/models/Mixin/Tag.php
+++ b/application/models/Mixin/Tag.php
@@ -141,12 +141,12 @@ class Mixin_Tag extends Omeka_Record_Mixin_AbstractMixin
         }
         
         $db = $this->_record->getDb();
-		foreach ($tags as $tag) {
-			$count = $this->_joinTable->count(array('tag' => $tag));
-			if ($count == 0) {
-				$db->delete($db->Tags, array('name = ?' => $tag));
-			}
-		}
+        foreach ($tags as $tag) {
+            $count = $this->_joinTable->count(array('tag' => $tag));
+            if ($count == 0) {
+                $db->delete($db->Tags, array('name = ?' => $tag));
+            }
+        }
 
         $nameForHook = strtolower($this->_type);
         fire_plugin_hook("remove_{$nameForHook}_tag", array('record' => $this->_record, 'removed' => $removed));

--- a/application/models/Table/Tag.php
+++ b/application/models/Table/Tag.php
@@ -191,4 +191,21 @@ class Table_Tag extends Omeka_Db_Table
         $tags = $db->fetchCol($sql, array($partialName . '%'));
         return $tags;
     }
+    
+    public function mergeTags($oldTagId, $newTagId, $recordType = '')
+    {
+        if ($recordType != '') $recordType = " AND record_type = '" . $recordType . "'";
+
+		$db = $this->getDb();
+        $sql = "UPDATE $db->RecordsTag SET tag_id = $newTagId, time = CURRENT_TIMESTAMP WHERE tag_id = $oldTagId" . $recordType . " AND record_id NOT IN (SELECT record_id FROM (SELECT DISTINCT record_id FROM $db->RecordsTag WHERE tag_id = $newTagId) AS tmptable)";
+		$db->query($sql);
+		$sql = "DELETE FROM $db->RecordsTag WHERE tag_id = $oldTagId" . $recordType;
+		$db->query($sql);
+		$sql = "DELETE FROM $db->Tag WHERE id = $oldTagId";
+		$db->query($sql);
+
+		$sql = "SELECT COUNT(id) AS tagCount FROM $db->RecordsTag WHERE tag_id = $newTagId" . $recordType;
+		$tagCount = $db->fetchOne($sql);
+		return $tagCount;
+    }
 }

--- a/application/views/helpers/CollectionSearchFilters.php
+++ b/application/views/helpers/CollectionSearchFilters.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Omeka
+ * 
+ * @copyright Copyright 2007-2012 Roy Rosenzweig Center for History and New Media
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GNU GPLv3
+ */
+
+/**
+ * Show the currently-active filters for a search/browse.
+ * 
+ * @package Omeka\View\Helper
+ */
+class Omeka_View_Helper_CollectionSearchFilters extends Zend_View_Helper_Abstract
+{
+    /**
+     * Get a list of the currently-active filters for collection browse.
+     *
+     * @param array $params Optional array of key-value pairs to use instead of
+     *  reading the current params from the request.
+     * @return string HTML output
+     */
+    public function collectionSearchFilters(array $params = null)
+    {
+        if ($params === null) {
+            $request = Zend_Controller_Front::getInstance()->getRequest();
+            $requestArray = $request->getParams();
+        } else {
+            $requestArray = $params;
+        }
+
+        $db = get_db();
+        $displayArray = array();
+        foreach ($requestArray as $key => $value) {
+            if ($value != null) {
+                $filter = ucfirst($key);
+                $displayValue = null;
+                switch ($key) {
+                    case 'public':
+                    case 'featured':
+                        $displayValue = ($value == 1 ? __('Yes') : $displayValue = __('No'));
+                        break;
+                }
+                if ($displayValue) {
+                    $displayArray[$filter] = $displayValue;
+                }
+            }
+        }
+
+        $displayArray = apply_filters('collection_search_filters', $displayArray, array('request_array' => $requestArray));
+
+        $html = '';
+        if (!empty($displayArray) || !empty($advancedArray)) {
+            $html .= '<div id="collection-filters">';
+            $html .= '<ul>';
+            foreach ($displayArray as $name => $query) {
+                $class = html_escape(strtolower(str_replace(' ', '-', $name)));
+                $html .= '<li class="' . $class . '">' . html_escape(__($name)) . ': ' . html_escape($query) . '</li>';
+            }
+            if (!empty($advancedArray)) {
+                foreach ($advancedArray as $j => $advanced) {
+                    $html .= '<li class="advanced">' . html_escape($advanced) . '</li>';
+                }
+            }
+            $html .= '</ul>';
+            $html .= '</div>';
+        }
+        return $html;
+    }
+}


### PR DESCRIPTION
Hi.
I've added some features as follows:

**TAGS**
- Added merging ability (when editing tag label, if the new label already exists then the old tags get linked to it and old label gets removed)
- Added autosuggest ability for tags field in batch-edit page
- Added tags deleting handling, with confirm message when needed

**COLLECTIONS BROWSE**
- Added Details feature, like in ITEMS BROWSE
- Added quick-filters feature, like in ITEMS BROWSE
- Added search-filter visualization, like in ITEMS BROWSE
- Added Delete link, like in ITEMS BROWSE

**DASHBOARD**
- Added general config option to set the number of recent Items/Collections displayed (default: 5)

Hope this helps.