### PR TITLE
advanced index_params for items api calls

### DIFF
--- a/application/libraries/Omeka/Controller/Plugin/Api.php
+++ b/application/libraries/Omeka/Controller/Plugin/Api.php
@@ -64,7 +64,7 @@ class Omeka_Controller_Plugin_Api extends Zend_Controller_Plugin_Abstract
             'index_params' => array(
                 'collection', 'item_type', 'featured', 'public', 'added_since',
                 'modified_since', 'owner', 'tags', 'excludeTags', 'hasImage',
-                'range', 'search',
+                'range', 'search', 'advanced'
             ),
         ),
         'files' => array(


### PR DESCRIPTION
to do more advanced queries with API calls (/api/items?advanced[0][joiner]=.... etc.)
without this we need to add index_params via 'api_resources' filter in a plugin