### PR TITLE
Add support for tagging collections.

### DIFF
--- a/admin/themes/default/collections/form-tabs.php
+++ b/admin/themes/default/collections/form-tabs.php
@@ -10,6 +10,11 @@ foreach ($elementSets as $key => $elementSet) {
     $tabs[$tabName] = $tabContent;    
 }
 
+ob_start();
+require 'tag-form.php';
+$tabs['Tags'] = ob_get_contents();
+ob_end_clean();
+
 $tabs = apply_filters('admin_collections_form_tabs', $tabs, array('collection' => $collection));
 ?>
 

--- a/admin/themes/default/collections/form.php
+++ b/admin/themes/default/collections/form.php
@@ -1,10 +1,15 @@
 <?php echo js_tag('vendor/tinymce/tinymce.min'); ?>
 <?php echo js_tag('elements'); ?>
 <?php echo js_tag('tabs'); ?>
+<?php echo js_tag('items'); ?>
 <script type="text/javascript">
 jQuery(document).ready(function () {
     Omeka.Tabs.initialize();
     
+    Omeka.Items.tagDelimiter = <?php echo js_escape(get_option('tag_delimiter')); ?>;
+    Omeka.Items.enableTagRemoval();
+    Omeka.Items.tagChoices('#tags', <?php echo js_escape(url(array('controller'=>'tags', 'action'=>'autocomplete'), 'default', array(), true)); ?>);
+
     Omeka.wysiwyg({
         selector: false,
         forced_root_block: false

--- a/admin/themes/default/collections/show.php
+++ b/admin/themes/default/collections/show.php
@@ -42,6 +42,15 @@ $collectionTitle = __('Collection #%s', metadata('collection', 'id')) . $collect
         <p><span class="label"><?php echo __('Featured'); ?>:</span> <?php echo ($collection->featured) ? __('Yes') : __('No'); ?></p>
     </div>
 
+    <?php if (metadata('collection', 'has tags')): ?>
+    <div class="tags panel">
+        <h4><?php echo __('Tags'); ?></h4>
+        <div id="tag-cloud">
+            <?php echo common('tag-list', compact('collection'), 'collections'); ?>
+        </div>
+     </div>
+    <?php endif; ?>
+
     <div class="total-items panel">
         <h4><?php echo __('Total Number of Items'); ?></h4>
         <p><?php echo link_to_items_in_collection(); ?></p>

--- a/admin/themes/default/collections/tag-form.php
+++ b/admin/themes/default/collections/tag-form.php
@@ -1,0 +1,31 @@
+<div id="tag-form" class="field">
+    <?php
+        $tags = $collection->getTags();
+    ?>
+    <input type="hidden" name="tags-to-add" id="tags-to-add" value="" />
+    <input type="hidden" name="tags-to-delete" id="tags-to-delete" value="" />
+    <div id="add-tags">
+        <label><?php echo __('Add Tags'); ?></label>           
+        <input type="text" name="tags" size="20" id="tags" class="textinput" value="" />
+        <p id="add-tags-explanation" class="explanation"><?php echo __('Separate tags with %s', option('tag_delimiter')); ?></p>
+        <input type="submit" name="add-tags-button" id="add-tags-button" class="green button" value="<?php echo __('Add Tags'); ?>" />
+    </div>
+    <div id="all-tags">
+    <?php if ($tags): ?>
+        <h3><?php echo __('All Tags'); ?></h3>
+        
+        <div class="tag-list">
+        <ul id="all-tags-list">
+            <?php foreach( $tags as $tag ): ?>
+                <li>
+                    <?php echo '<span class="tag">' . html_escape($tag->name) . '</span>';
+                          echo '<span class="undo-remove-tag"><a href="#">' . __('Undo') . '</a></span>';
+                          echo '<span class="remove-tag"><a href="#">' . __('Remove') . '</a></span>'; ?>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+        </div>
+    <?php endif; ?>
+    </div>
+</div>
+<?php fire_plugin_hook('admin_collections_form_tags', array('collection' => $collection, 'view' => $this)); ?>

--- a/admin/themes/default/collections/tag-list.php
+++ b/admin/themes/default/collections/tag-list.php
@@ -1,0 +1,9 @@
+<?php if ($collection->Tags): ?>
+    <ul class="tags">
+        <?php foreach( $collection->Tags as $key => $tag ): ?>
+        <li class="tag">
+            <a href="<?php echo html_escape(url('collections/browse', array('tags' => $tag->name))); ?>"><?php echo html_escape($tag->name); ?></a>
+        </li>
+        <?php endforeach; ?>
+    </ul>
+<?php endif; ?>

--- a/admin/themes/default/collections/tags.php
+++ b/admin/themes/default/collections/tags.php
@@ -1,0 +1,11 @@
+<?php
+$pageTitle = __('Browse Collections by Tag');
+echo head(array('title' => $pageTitle));
+echo flash();
+?>
+<?php if (count($tags)): ?>
+    <?php echo tag_cloud($tags, 'collections/browse'); ?>
+<?php else: ?>
+    <p><?php echo __('There are no tags to display. You must first tag some collections.'); ?></p>
+<?php endif; ?>
+<?php echo foot(); ?>

--- a/application/controllers/CollectionsController.php
+++ b/application/controllers/CollectionsController.php
@@ -52,6 +52,20 @@ class CollectionsController extends Omeka_Controller_AbstractActionController
         parent::editAction();
     }
 
+    /**
+     * Finds all tags associated with collections (used for tag cloud)
+     */
+    public function tagsAction()
+    {
+        $params = array_merge(
+            array('sort_field' => 'name'),
+            $this->_getAllParams(),
+            array('type' => 'Collection')
+        );
+        $tags = $this->_helper->db->getTable('Tag')->findBy($params);
+        $this->view->assign(compact('tags'));
+    }
+
     protected function _getAddSuccessMessage($collection)
     {
         $collectionTitle = $this->_getElementMetadata($collection, 'Dublin Core', 'Title');

--- a/application/models/Api/Collection.php
+++ b/application/models/Api/Collection.php
@@ -36,6 +36,7 @@ class Api_Collection extends Omeka_Record_Api_AbstractRecordAdapter
                 'url' => self::getResourceUrl("/items?collection={$record->id}"),
                 'resource' => 'items',
             ),
+            'tags' = $this->getTagRepresentations($record),
             'element_texts' => $this->getElementTextRepresentations($record),
         );
 
@@ -56,6 +57,7 @@ class Api_Collection extends Omeka_Record_Api_AbstractRecordAdapter
         if (isset($data->featured)) {
             $record->featured = $data->featured;
         }
+        $this->setTagData($record, $data);
         $this->setElementTextData($record, $data);
     }
 

--- a/application/models/Collection.php
+++ b/application/models/Collection.php
@@ -54,6 +54,7 @@ class Collection extends Omeka_Record_AbstractRecord implements Zend_Acl_Resourc
      * @see Omeka_Record_AbstractRecord::__get
      */
     protected $_related = array(
+        'Tags' => 'getTags',
         'ElementTexts' => 'getAllElementTexts'
     );
 
@@ -62,6 +63,7 @@ class Collection extends Omeka_Record_AbstractRecord implements Zend_Acl_Resourc
      */
     protected function _initializeMixins()
     {
+        $this->_mixins[] = new Mixin_Tag($this);
         $this->_mixins[] = new Mixin_PublicFeatured($this);
         $this->_mixins[] = new Mixin_Owner($this);
         $this->_mixins[] = new Mixin_ElementText($this);
@@ -210,6 +212,16 @@ class Collection extends Omeka_Record_AbstractRecord implements Zend_Acl_Resourc
     {
         if (!$this->public) {
             $this->setSearchTextPrivate();
+        }
+
+        if ($args['post']) {
+            $post = $args['post'];
+
+            // Save/delete the tags.
+            if (isset($post['tags-to-add'])) {
+                $this->addTags($post['tags-to-add']);
+                $this->deleteTags($post['tags-to-delete']);
+            }
         }
     }
 


### PR DESCRIPTION
We needed a means to organize Items, Collections and Exhibits together for different divisions of our libraries. Items and Collections have Dublin Core fields, but Exhibits do not. Items and Exhibits have tags, but Collections do not. Investigating options, adding tags to Collections appeared to be the easiest to implement. Though it does not appear that the functionality could be added via a plugin, hence this pull request. We duplicated the code from Items as much as possible.