### PR TITLE
Allow linking to records of any type from Browse Tags page.

### DIFF
--- a/admin/themes/default/tags/browse.php
+++ b/admin/themes/default/tags/browse.php
@@ -19,7 +19,7 @@ echo flash();
     <h2><?php echo __('Editing Tags'); ?></h2>
     
     <ol>
-        <li><?php echo __('This number counts all records associated with a tag. Filtering "Record types" to "Items" will provide links to all items containing the tag.'); ?></li>
+        <li><?php echo __('This number counts all records associated with a tag. Filtering "Record Types" will provide links to all records of that type containing the tag.'); ?></li>
         <li><?php echo __('To edit the tag name, click the name and begin editing, and hit "enter" to save. To cancel an edit, click the ESC key or click away from the tag.'); ?></li>
         <li><?php echo __('To delete a tag, click the X. Deleting a tag will not delete the tagged records.'); ?></li>
     </ol>
@@ -85,8 +85,8 @@ echo flash();
         <ul class="tag-list">
         <?php foreach ($tags as $tag): ?>
             <li>
-            <?php if($browse_for == 'Item'):?>
-                <a href="<?php echo html_escape(url('items/browse', array('tags' => $tag->name))); ?>" class="count"><?php echo $tag['tagCount']; ?></a>
+            <?php if($browse_for != 'All'):?>
+                <?php echo link_to(strtolower(Inflector::pluralize($browse_for)), 'browse', $tag['tagCount'], array('class' => 'count'), array('tags' => $tag->name)); ?>
             <?php else: ?>
                 <span class="count"><?php echo $tag['tagCount']; ?></span>
             <?php endif; ?>


### PR DESCRIPTION
Our librarians requested that they be able to navigate to records besides Items from the Browse Tags page. This attempts to do so in a generic way, so that as long as you are filtering to a specific Record Type, the number next to a tag links to all records of that type with that tag. This works for Exhibits, as well as Collections as I proposed in #963.