### PR TITLE
Use bcrypt for passwords instead of SHA1

### DIFF
--- a/application/libraries/Omeka/Auth/Adapter/UserTable.php
+++ b/application/libraries/Omeka/Auth/Adapter/UserTable.php
@@ -42,7 +42,9 @@ class Omeka_Auth_Adapter_UserTable extends Zend_Auth_Adapter_DbTable
         $resultIdentities = parent::_authenticateQuerySelect($dbSelect);
         $correctResult = array();
         foreach ($resultIdentities as $identity) {
-            if (password_verify($this->_credential, $identity['password'])) {
+            if ((version_compare(PHP_VERSION, '5.5.0') >= 0) ? 
+                password_verify($this->_credential, $identity['password']) :
+                (crypt($this->_credential, substr($identity['password'], 0, 29).'$') == $identity['password'])) {
                 $identity['zend_auth_credential_match'] = 1;
                 $correctResult[] = $identity;
             }

--- a/application/libraries/Omeka/Auth/Adapter/UserTable.php
+++ b/application/libraries/Omeka/Auth/Adapter/UserTable.php
@@ -42,9 +42,7 @@ class Omeka_Auth_Adapter_UserTable extends Zend_Auth_Adapter_DbTable
         $resultIdentities = parent::_authenticateQuerySelect($dbSelect);
         $correctResult = array();
         foreach ($resultIdentities as $identity) {
-            if ((version_compare(PHP_VERSION, '5.5.0') >= 0) ? 
-                password_verify($this->_credential, $identity['password']) :
-                (crypt($this->_credential, substr($identity['password'], 0, 29).'$') == $identity['password'])) {
+            if (password_verify($this->_credential, $identity['password'])) {
                 $identity['zend_auth_credential_match'] = 1;
                 $correctResult[] = $identity;
             }

--- a/application/libraries/Omeka/Auth/Adapter/UserTable.php
+++ b/application/libraries/Omeka/Auth/Adapter/UserTable.php
@@ -22,7 +22,32 @@ class Omeka_Auth_Adapter_UserTable extends Zend_Auth_Adapter_DbTable
                             $db->User,
                             'username',
                             'password',
-                            'SHA1(CONCAT(salt, ?)) AND active = 1');
+                            'active = 1');
+    }
+
+    /**
+     * Accept a Zend_Db_Select object and performs a query against
+     * the database with that object.
+     * 
+     * Overrides the Zend implementation to check the password using
+     * password_verify().
+     *
+     * @param Zend_Db_Select $dbSelect
+     * @throws Zend_Auth_Adapter_Exception - when an invalid select
+     *                                       object is encountered
+     * @return array
+     */
+    protected function _authenticateQuerySelect(Zend_Db_Select $dbSelect)
+    {
+        $resultIdentities = parent::_authenticateQuerySelect($dbSelect);
+        $correctResult = array();
+        foreach ($resultIdentities as $identity) {
+            if (password_verify($this->_credential, $identity['password'])) {
+                $identity['zend_auth_credential_match'] = 1;
+                $correctResult[] = $identity;
+            }
+        }
+        return $correctResult;
     }
 
     /**

--- a/application/libraries/Omeka/Validate/UserPassword.php
+++ b/application/libraries/Omeka/Validate/UserPassword.php
@@ -53,9 +53,7 @@ class Omeka_Validate_UserPassword extends Zend_Validate_Abstract
     public function isValid($value, $context = null)
     {
         assert($this->_user->password !== null);
-        $valid = (version_compare(PHP_VERSION, '5.5.0') >= 0) ? 
-            password_verify($value, $this->_user->password) :
-            (crypt($value, substr($this->_user->password, 0, 29).'$') == $this->_user->password);
+        $valid = password_verify($value, $this->_user->password);
         if (!$valid) {
             $this->_error(self::INVALID);
         }

--- a/application/libraries/Omeka/Validate/UserPassword.php
+++ b/application/libraries/Omeka/Validate/UserPassword.php
@@ -53,7 +53,7 @@ class Omeka_Validate_UserPassword extends Zend_Validate_Abstract
     public function isValid($value, $context = null)
     {
         assert($this->_user->password !== null);
-        $valid = $this->_user->hashPassword($value) === $this->_user->password;
+        $valid = password_verify($value, $this->_user->password);
         if (!$valid) {
             $this->_error(self::INVALID);
         }

--- a/application/libraries/Omeka/Validate/UserPassword.php
+++ b/application/libraries/Omeka/Validate/UserPassword.php
@@ -53,7 +53,9 @@ class Omeka_Validate_UserPassword extends Zend_Validate_Abstract
     public function isValid($value, $context = null)
     {
         assert($this->_user->password !== null);
-        $valid = password_verify($value, $this->_user->password);
+        $valid = (version_compare(PHP_VERSION, '5.5.0') >= 0) ? 
+            password_verify($value, $this->_user->password) :
+            (crypt($value, substr($this->_user->password, 0, 29).'$') == $this->_user->password);
         if (!$valid) {
             $this->_error(self::INVALID);
         }

--- a/application/migrations/20220607161800_growUserPassword.php
+++ b/application/migrations/20220607161800_growUserPassword.php
@@ -15,6 +15,6 @@ class growUserPassword extends Omeka_Db_Migration_AbstractMigration
 {
     public function up()
     {
-        $this->db->query("ALTER TABLE {$this->db->User} MODIFY `password` VARCHAR(64) NOT NULL");
+        $this->db->query("ALTER TABLE {$this->db->User} MODIFY `password` VARCHAR(255) NOT NULL");
     }
 }

--- a/application/migrations/20220607161800_growUserPassword.php
+++ b/application/migrations/20220607161800_growUserPassword.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Omeka
+ *
+ * @copyright Copyright 2007-2022 Roy Rosenzweig Center for History and New Media
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GNU GPLv3
+ */
+
+/**
+ * Increase length of salt and hash for user passwords
+ *
+ * @package Omeka\Db\Migration
+ */
+class growUserPassword extends Omeka_Db_Migration_AbstractMigration
+{
+    public function up()
+    {
+        $this->db->query("ALTER TABLE {$this->db->User} MODIFY `password` VARCHAR(64) NOT NULL");
+    }
+}

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -285,6 +285,6 @@ class User extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
      */
     public function hashPassword($password)
     {
-        return (version_compare(PHP_VERSION, '5.5.0') >= 0) ? password_hash($password, PASSWORD_BCRYPT) : crypt($password, '$2a$10$'.substr(base64_encode(sha1(mt_rand())), 0, 22).'$');
+        return password_hash($password, PASSWORD_BCRYPT);
     }
 }

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -285,6 +285,6 @@ class User extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
      */
     public function hashPassword($password)
     {
-        return password_hash($password, PASSWORD_BCRYPT);
+        return (version_compare(PHP_VERSION, '5.5.0') >= 0) ? password_hash($password, PASSWORD_BCRYPT) : crypt($password, '$2a$10$'.substr(base64_encode(sha1(mt_rand())), 0, 22).'$');
     }
 }

--- a/application/models/User.php
+++ b/application/models/User.php
@@ -210,8 +210,8 @@ class User extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
         if (!$user) {
             return false;
         }
-        // Check unsalted SHA1 password format (with match)
-        if (empty($user->salt) && $user->password != sha1($password)) {
+        // Check bcrypt password format
+        if (!empty($user->salt) && $user->salt == 'bcrypt') {
             return false;
         }
         // Check salted SHA1 password format (with match)
@@ -219,8 +219,8 @@ class User extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
             && $user->password != sha1($user->salt . $password)) {
             return false;
         }
-        // Check bcrypt password format
-        if (!empty($user->salt) && $user->salt == 'bcrypt') {
+        // Check unsalted SHA1 password format (with match)
+        if (empty($user->salt) && $user->password != sha1($password)) {
             return false;
         }
         $user->setPassword($password);

--- a/application/schema/users.sql
+++ b/application/schema/users.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `%PREFIX%users` (
   `username` varchar(30) collate utf8_unicode_ci NOT NULL,
   `name` text collate utf8_unicode_ci NOT NULL,
   `email` text collate utf8_unicode_ci NOT NULL,
-  `password` varchar(64) collate utf8_unicode_ci default NULL,
+  `password` varchar(255) collate utf8_unicode_ci default NULL,
   `salt` varchar(16) collate utf8_unicode_ci default NULL,  
   `active` tinyint NOT NULL,
   `role` varchar(40) collate utf8_unicode_ci NOT NULL default 'default',

--- a/application/schema/users.sql
+++ b/application/schema/users.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS `%PREFIX%users` (
   `username` varchar(30) collate utf8_unicode_ci NOT NULL,
   `name` text collate utf8_unicode_ci NOT NULL,
   `email` text collate utf8_unicode_ci NOT NULL,
-  `password` varchar(40) collate utf8_unicode_ci default NULL,
+  `password` varchar(64) collate utf8_unicode_ci default NULL,
   `salt` varchar(16) collate utf8_unicode_ci default NULL,  
   `active` tinyint NOT NULL,
   `role` varchar(40) collate utf8_unicode_ci NOT NULL default 'default',

--- a/application/tests/suite/Controllers/ChangePasswordTest.php
+++ b/application/tests/suite/Controllers/ChangePasswordTest.php
@@ -130,8 +130,10 @@ class Omeka_Controllers_ChangePasswordTest extends Omeka_Test_AppTestCase
 
     private function _assertPasswordIs($pass, $msg = '')
     {
-        $this->assertTrue(password_verify($pass,
-            $this->db->fetchOne("SELECT password FROM omeka_users WHERE id = 1")),
+        $passHash = $this->db->fetchOne("SELECT password FROM omeka_users WHERE id = 1");
+        $this->assertTrue((version_compare(PHP_VERSION, '5.5.0') >= 0) ?
+            password_verify($pass, $passHash) : 
+            (crypt($pass, substr($passHash, 0, 29).'$') == $passHash),
             $msg);
     }
 

--- a/application/tests/suite/Controllers/ChangePasswordTest.php
+++ b/application/tests/suite/Controllers/ChangePasswordTest.php
@@ -130,9 +130,9 @@ class Omeka_Controllers_ChangePasswordTest extends Omeka_Test_AppTestCase
 
     private function _assertPasswordIs($pass, $msg = '')
     {
-        $this->assertEquals($this->db->fetchOne("SELECT password FROM omeka_users WHERE id = 1"),
-                            $this->user->hashPassword($pass),
-                            $msg);
+        $this->assertTrue(password_verify($pass,
+            $this->db->fetchOne("SELECT password FROM omeka_users WHERE id = 1")),
+            $msg);
     }
 
     private function _assertSaltNotChanged()

--- a/application/tests/suite/Controllers/ChangePasswordTest.php
+++ b/application/tests/suite/Controllers/ChangePasswordTest.php
@@ -130,10 +130,8 @@ class Omeka_Controllers_ChangePasswordTest extends Omeka_Test_AppTestCase
 
     private function _assertPasswordIs($pass, $msg = '')
     {
-        $passHash = $this->db->fetchOne("SELECT password FROM omeka_users WHERE id = 1");
-        $this->assertTrue((version_compare(PHP_VERSION, '5.5.0') >= 0) ?
-            password_verify($pass, $passHash) : 
-            (crypt($pass, substr($passHash, 0, 29).'$') == $passHash),
+        $this->assertTrue(password_verify($pass,
+            $this->db->fetchOne("SELECT password FROM omeka_users WHERE id = 1")),
             $msg);
     }
 

--- a/application/tests/suite/Controllers/LoginTest.php
+++ b/application/tests/suite/Controllers/LoginTest.php
@@ -30,9 +30,7 @@ class Omeka_Controller_LoginTest extends Omeka_Test_AppTestCase
         $newUser = $dbAdapter->fetchRow("SELECT `salt`, `password` FROM omeka_users WHERE id = 1");
         $this->assertNotNull($newUser);
         $this->assertEquals($newUser['salt'], 'bcrypt');
-        $this->assertTrue((version_compare(PHP_VERSION, '5.5.0') >= 0) ?
-            password_verify('foobar', $newUser['password']) : 
-            (crypt('foobar', substr($newUser['password'], 0, 29).'$') == $newUser['password']));
+        $this->assertTrue(password_verify('foobar', $newUser['password']));
     }
 
     public function testUpgradingSaltedPasswordForUser()
@@ -52,9 +50,7 @@ class Omeka_Controller_LoginTest extends Omeka_Test_AppTestCase
         $newUser = $dbAdapter->fetchRow("SELECT `salt`, `password` FROM omeka_users WHERE id = 1");
         $this->assertNotNull($newUser);
         $this->assertEquals($newUser['salt'], 'bcrypt');
-        $this->assertTrue((version_compare(PHP_VERSION, '5.5.0') >= 0) ?
-            password_verify('barbaz', $newUser['password']) : 
-            (crypt('barbaz', substr($newUser['password'], 0, 29).'$') == $newUser['password']));
+        $this->assertTrue(password_verify('barbaz', $newUser['password']));
     }
 
     public function testValidLogin()

--- a/application/tests/suite/Controllers/LoginTest.php
+++ b/application/tests/suite/Controllers/LoginTest.php
@@ -30,7 +30,9 @@ class Omeka_Controller_LoginTest extends Omeka_Test_AppTestCase
         $newUser = $dbAdapter->fetchRow("SELECT `salt`, `password` FROM omeka_users WHERE id = 1");
         $this->assertNotNull($newUser);
         $this->assertEquals($newUser['salt'], 'bcrypt');
-        $this->assertTrue(password_verify('foobar', $newUser['password']));
+        $this->assertTrue((version_compare(PHP_VERSION, '5.5.0') >= 0) ?
+            password_verify('foobar', $newUser['password']) : 
+            (crypt('foobar', substr($newUser['password'], 0, 29).'$') == $newUser['password']));
     }
 
     public function testUpgradingSaltedPasswordForUser()
@@ -50,7 +52,9 @@ class Omeka_Controller_LoginTest extends Omeka_Test_AppTestCase
         $newUser = $dbAdapter->fetchRow("SELECT `salt`, `password` FROM omeka_users WHERE id = 1");
         $this->assertNotNull($newUser);
         $this->assertEquals($newUser['salt'], 'bcrypt');
-        $this->assertTrue(password_verify('barbaz', $newUser['password']));
+        $this->assertTrue((version_compare(PHP_VERSION, '5.5.0') >= 0) ?
+            password_verify('barbaz', $newUser['password']) : 
+            (crypt('barbaz', substr($newUser['password'], 0, 29).'$') == $newUser['password']));
     }
 
     public function testValidLogin()

--- a/application/tests/suite/Controllers/LoginTest.php
+++ b/application/tests/suite/Controllers/LoginTest.php
@@ -27,10 +27,10 @@ class Omeka_Controller_LoginTest extends Omeka_Test_AppTestCase
         // that the user account was upgraded to use bcrypt.
         $this->_login('foobar123', 'foobar');
         $this->assertRedirectTo('/', $this->getResponse()->getBody());
-        $newUser = $dbAdapter->fetchOne("SELECT `salt`, `password` FROM omeka_users WHERE id = 1");
+        $newUser = $dbAdapter->fetchRow("SELECT `salt`, `password` FROM omeka_users WHERE id = 1");
         $this->assertNotNull($newUser);
         $this->assertEquals($newUser['salt'], 'bcrypt');
-        $this->assert(password_verify('foobar', $newUser['password']));
+        $this->assertTrue(password_verify('foobar', $newUser['password']));
     }
 
     public function testUpgradingSaltedPasswordForUser()
@@ -39,7 +39,7 @@ class Omeka_Controller_LoginTest extends Omeka_Test_AppTestCase
         $dbAdapter = $this->db->getAdapter();
         // Reset the username/pass to the old style (SHA1 w/ salt).
         $dbAdapter->update('omeka_users',
-                            array('password' => sha1('0123456789abcdef', 'barbaz'),
+                            array('password' => sha1('0123456789abcdef' . 'barbaz'),
                                   'salt' => '0123456789abcdef'),
                            'id = 1');
 
@@ -47,10 +47,10 @@ class Omeka_Controller_LoginTest extends Omeka_Test_AppTestCase
         // that the user account was upgraded to use bcrypt.
         $this->_login('foobar123', 'barbaz');
         $this->assertRedirectTo('/', $this->getResponse()->getBody());
-        $newUser = $dbAdapter->fetchOne("SELECT `salt`, `password` FROM omeka_users WHERE id = 1");
+        $newUser = $dbAdapter->fetchRow("SELECT `salt`, `password` FROM omeka_users WHERE id = 1");
         $this->assertNotNull($newUser);
         $this->assertEquals($newUser['salt'], 'bcrypt');
-        $this->assert(password_verify('barbaz', $newUser['password']));
+        $this->assertTrue(password_verify('barbaz', $newUser['password']));
     }
 
     public function testValidLogin()


### PR DESCRIPTION
This changes the password hashing method to bcrypt, which is much more resistant to mass computation and now the industry standard for storing passwords.