### PR TITLE
Improve search form a11y labeling.

### DIFF
--- a/application/views/helpers/SearchForm.php
+++ b/application/views/helpers/SearchForm.php
@@ -54,7 +54,7 @@ class Omeka_View_Helper_SearchForm extends Zend_View_Helper_Abstract
 
         // Set the default submit value.
         if (!isset($options['submit_value'])) {
-            $options['submit_value'] = __('Search');
+            $options['submit_value'] = __('Submit');
         }
 
         // Set the default form attributes.
@@ -67,6 +67,9 @@ class Omeka_View_Helper_SearchForm extends Zend_View_Helper_Abstract
         }
         if (!isset($options['form_attributes']['id'])) {
             $options['form_attributes']['id'] = 'search-form';
+        }
+        if (!isset($options['form_attributes']['aria-label'])) {
+            $options['form_attributes']['aria-label'] = __('Search');
         }
         $options['form_attributes']['method'] = 'get';
 

--- a/application/views/scripts/javascripts/globals.js
+++ b/application/views/scripts/javascripts/globals.js
@@ -18,13 +18,11 @@ if (!Omeka) {
     // Show advanced options for site-wide search.
     Omeka.showAdvancedForm = function () {
         var advanced_form = $('#advanced-form');
-        var show_advanced = '<a href="#" class="show-advanced button">Advanced Search</a>';
-        var search_submit = $('#search-form button');
 
         // Set up classes and DOM elements jQuery will use.
         if (advanced_form.length > 0) {
             $('#search-container').addClass('with-advanced');
-            advanced_form.addClass('closed').before(show_advanced);
+            advanced_form.addClass('closed');
         }
 
         $('.show-advanced').click(function(e) {

--- a/application/views/scripts/search/search-form.php
+++ b/application/views/scripts/search/search-form.php
@@ -1,6 +1,15 @@
 <?php echo $this->form('search-form', $options['form_attributes']); ?>
-    <?php echo $this->formText('query', $filters['query'], array('title' => __('Search'), 'aria-labelledby' => __('submit_search'))); ?>
+    <?php 
+        echo $this->formText('query', $filters['query'], array(
+            'title' => __('Query'), 
+            'aria-label' => __('Query'), 
+            'aria-labelledby' => 'search-form query'
+        )); 
+    ?>
     <?php if ($options['show_advanced']): ?>
+    <button id="search-options" type="button" class="show-advanced button" aria-label="<?php echo __('Options'); ?>" title="<?php echo __('Options'); ?>" aria-labelledby="search-form search-options">
+        <span class="icon" aria-hidden="true"></span>
+    </button>
     <div id="advanced-form">
         <fieldset id="query-types">
             <legend><?php echo __('Search using this query type:'); ?></legend>
@@ -24,5 +33,16 @@
         <?php echo $this->formHidden('record_types[]', $type, array('id' => '')); ?>
         <?php endforeach; ?>
     <?php endif; ?>
-    <?php echo $this->formButton('submit_search', $options['submit_value'], array('type' => 'submit')); ?>
+    <?php 
+        echo $this->formButton('submit_search', $options['submit_value'], array(
+            'type' => 'submit', 
+            'title' => __('Submit'), 
+            'class' => 'button', 
+            'content' => '<span class="icon" aria-hidden="true"></span>', 
+            'escape' => false,
+            'aria-label' => __('Submit'),
+            'aria-labelledby' => 'search-form submit_search'
+            )
+        ); 
+    ?>
 </form>


### PR DESCRIPTION
* Provide icon spans, hidden from screen readers. In previous state, screen readers would sometimes read pseudo element content used for icons.
* Provide aria labels for each form element.
* Move markup from js to partial.