### PR TITLE
Improve labeling for "Narrow by specific fields" on advanced search

### DIFF
--- a/application/views/scripts/css/public.css
+++ b/application/views/scripts/css/public.css
@@ -1,0 +1,11 @@
+.sr-only {
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px; }
+
+/*# sourceMappingURL=public.css.map */

--- a/application/views/scripts/css/sass/public.scss
+++ b/application/views/scripts/css/sass/public.scss
@@ -1,0 +1,10 @@
+.sr-only {
+    border: 0;
+    clip: rect(0, 0, 0, 0);
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+}

--- a/application/views/scripts/items/search-form.php
+++ b/application/views/scripts/items/search-form.php
@@ -21,8 +21,15 @@ $formAttributes['method'] = 'GET';
         ?>
         </div>
     </div>
+    <div id="search-narrow-by-field-alerts" class="sr-only alerts" aria-atomic="true" aria-live="polite">
+        <p><?php echo __('Number of rows in "%s":', __('Narrow by Specific Fields')); ?> <span class="count">1</span></p>
+    </div>
     <div id="search-narrow-by-fields" class="field">
-        <div class="label"><?php echo __('Narrow by Specific Fields'); ?></div>
+        <div id="search-narrow-by-fields-label" class="label"><?php echo __('Narrow by Specific Fields'); ?></div>
+        <div id="search-narrow-by-fields-property" class="label sr-only"><?php echo __('Search Property'); ?></div>
+        <div id="search-narrow-by-fields-type" class="label sr-only"><?php echo __('Search Type'); ?></div>
+        <div id="search-narrow-by-fields-terms" class="label sr-only"><?php echo __('Search terms'); ?></div>
+        <div id="search-narrow-by-fields-joiner" class="label sr-only"><?php echo __('Search Joiner'); ?></div>
         <div class="inputs">
         <?php
         // If the form has been submitted, retain the number of search
@@ -34,70 +41,84 @@ $formAttributes['method'] = 'GET';
         }
 
         //Here is where we actually build the search form
+        //The POST looks like =>
+        // advanced[0] =>
+        //[field] = 'description'
+        //[type] = 'contains'
+        //[terms] = 'foobar'
+        //etc
         foreach ($search as $i => $rows): ?>
             <div class="search-entry">
-                <?php
-                //The POST looks like =>
-                // advanced[0] =>
-                //[field] = 'description'
-                //[type] = 'contains'
-                //[terms] = 'foobar'
-                //etc
-                echo $this->formSelect(
-                    "advanced[$i][joiner]",
-                    @$rows['joiner'],
-                    array(
-                        'title' => __("Search Joiner"),
-                        'id' => null,
-                        'class' => 'advanced-search-joiner'
-                    ),
-                    array(
-                        'and' => __('AND'),
-                        'or' => __('OR'),
-                    )
-                );
-                echo $this->formSelect(
-                    "advanced[$i][element_id]",
-                    @$rows['element_id'],
-                    array(
-                        'title' => __("Search Field"),
-                        'id' => null,
-                        'class' => 'advanced-search-element'
-                    ),
-                    get_table_options('Element', null, array(
-                        'record_types' => array('Item', 'All'),
-                        'sort' => 'orderBySet')
-                    )
-                );
-                echo $this->formSelect(
-                    "advanced[$i][type]",
-                    @$rows['type'],
-                    array(
-                        'title' => __("Search Type"),
-                        'id' => null,
-                        'class' => 'advanced-search-type'
-                    ),
-                    label_table_options(array(
-                        'contains' => __('contains'),
-                        'does not contain' => __('does not contain'),
-                        'is exactly' => __('is exactly'),
-                        'is empty' => __('is empty'),
-                        'is not empty' => __('is not empty'),
-                        'starts with' => __('starts with'),
-                        'ends with' => __('ends with'))
-                    )
-                );
-                echo $this->formText(
-                    "advanced[$i][terms]",
-                    @$rows['terms'],
-                    array(
-                        'size' => '20',
-                        'title' => __("Search Terms"),
-                        'id' => null,
-                        'class' => 'advanced-search-terms'
-                    )
-                );
-                ?>
+                <div class="input advanced-search-joiner"> 
+                    <span aria-hidden="true" class="visible-label"><?php echo __('Joiner'); ?></span>
+                    <?php 
+                    echo $this->formSelect(
+                        "advanced[$i][joiner]",
+                        @$rows['joiner'],
+                        array(
+                            'id' => null,
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-narrow-by-fields-joiner',
+                        ),
+                        array(
+                            'and' => __('AND'),
+                            'or' => __('OR'),
+                        )
+                    );
+                    ?>
+                </div>
+                <div class="input advanced-search-element"> 
+                    <span aria-hidden="true" class="visible-label"><?php echo __('Property'); ?></span>
+                    <?php 
+                    echo $this->formSelect(
+                        "advanced[$i][element_id]",
+                        @$rows['element_id'],
+                        array(
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-narrow-by-fields-property',
+                            'id' => null,
+                        ),
+                        get_table_options('Element', null, array(
+                            'record_types' => array('Item', 'All'),
+                            'sort' => 'orderBySet')
+                        )
+                    );
+                    ?>
+                </div>
+                <div class="input advanced-search-type"> 
+                    <span aria-hidden="true" class="visible-label"><?php echo __('Type'); ?></span>
+                    <?php 
+                    echo $this->formSelect(
+                        "advanced[$i][type]",
+                        @$rows['type'],
+                        array(
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-narrow-by-fields-type',
+                            'id' => null,
+                        ),
+                        label_table_options(array(
+                            'contains' => __('contains'),
+                            'does not contain' => __('does not contain'),
+                            'is exactly' => __('is exactly'),
+                            'is empty' => __('is empty'),
+                            'is not empty' => __('is not empty'),
+                            'starts with' => __('starts with'),
+                            'ends with' => __('ends with'))
+                        )
+                    );
+                    ?>
+                </div>
+                <div class="input advanced-search-terms">
+                    <span aria-hidden="true" class="visible-label"><?php echo __('Terms'); ?></span>
+                    <?php 
+                    echo $this->formText(
+                        "advanced[$i][terms]",
+                        @$rows['terms'],
+                        array(
+                            'size' => '20',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-narrow-by-fields-terms',
+                            'id' => null,
+                        )
+                    );
+                    ?>
+                </div>
                 <button type="button" class="remove_search" disabled="disabled" style="display: none;"><?php echo __('Remove field'); ?></button>
             </div>
         <?php endforeach; ?>

--- a/application/views/scripts/items/search-form.php
+++ b/application/views/scripts/items/search-form.php
@@ -26,10 +26,11 @@ $formAttributes['method'] = 'GET';
     </div>
     <div id="search-narrow-by-fields" class="field">
         <div id="search-narrow-by-fields-label" class="label"><?php echo __('Narrow by Specific Fields'); ?></div>
-        <div id="search-narrow-by-fields-property" class="label sr-only"><?php echo __('Search Property'); ?></div>
-        <div id="search-narrow-by-fields-type" class="label sr-only"><?php echo __('Search Type'); ?></div>
-        <div id="search-narrow-by-fields-terms" class="label sr-only"><?php echo __('Search terms'); ?></div>
-        <div id="search-narrow-by-fields-joiner" class="label sr-only"><?php echo __('Search Joiner'); ?></div>
+        <div id="search-narrow-by-fields-property" class="label sr-only" aria-hidden="true"><?php echo __('Search Property'); ?></div>
+        <div id="search-narrow-by-fields-type" class="label sr-only" aria-hidden="true"><?php echo __('Search Type'); ?></div>
+        <div id="search-narrow-by-fields-terms" class="label sr-only" aria-hidden="true"><?php echo __('Search Terms'); ?></div>
+        <div id="search-narrow-by-fields-joiner" class="label sr-only" aria-hidden="true"><?php echo __('Search Joiner'); ?></div>
+        <div id="search-narrow-by-fields-remove-field" class="label aria-hidden="true"><?php echo __('Remove field'); ?></div>
         <div class="inputs">
         <?php
         // If the form has been submitted, retain the number of search
@@ -48,7 +49,8 @@ $formAttributes['method'] = 'GET';
         //[terms] = 'foobar'
         //etc
         foreach ($search as $i => $rows): ?>
-            <div class="search-entry">
+            <?php $index = $i + 1; // The index must start at 1 for accessible labels. ;?>
+            <div class="search-entry" id="search-row-<?php echo $index; ?>" aria-label="<?php echo __('Row %s', $index); ?>">
                 <div class="input advanced-search-joiner"> 
                     <span aria-hidden="true" class="visible-label"><?php echo __('Joiner'); ?></span>
                     <?php 
@@ -57,7 +59,7 @@ $formAttributes['method'] = 'GET';
                         @$rows['joiner'],
                         array(
                             'id' => null,
-                            'aria-labelledby' => 'search-narrow-by-fields-label search-narrow-by-fields-joiner',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $index . ' search-narrow-by-fields-joiner',
                         ),
                         array(
                             'and' => __('AND'),
@@ -73,7 +75,7 @@ $formAttributes['method'] = 'GET';
                         "advanced[$i][element_id]",
                         @$rows['element_id'],
                         array(
-                            'aria-labelledby' => 'search-narrow-by-fields-label search-narrow-by-fields-property',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $index . ' search-narrow-by-fields-property',
                             'id' => null,
                         ),
                         get_table_options('Element', null, array(
@@ -90,7 +92,7 @@ $formAttributes['method'] = 'GET';
                         "advanced[$i][type]",
                         @$rows['type'],
                         array(
-                            'aria-labelledby' => 'search-narrow-by-fields-label search-narrow-by-fields-type',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $index . ' search-narrow-by-fields-type',
                             'id' => null,
                         ),
                         label_table_options(array(
@@ -113,13 +115,13 @@ $formAttributes['method'] = 'GET';
                         @$rows['terms'],
                         array(
                             'size' => '20',
-                            'aria-labelledby' => 'search-narrow-by-fields-label search-narrow-by-fields-terms',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $index . ' search-narrow-by-fields-terms',
                             'id' => null,
                         )
                     );
                     ?>
                 </div>
-                <button type="button" class="remove_search" disabled="disabled" style="display: none;"><?php echo __('Remove field'); ?></button>
+                <button type="button" class="remove_search" disabled="disabled" style="display: none;" aria-labelledby="search-narrow-by-fields-label search-row-<?php echo $index; ?> search-narrow-by-fields-remove-field" title="<?php echo __('Remove field'); ?>"><?php echo __('Remove field'); ?></button>
             </div>
         <?php endforeach; ?>
         </div>

--- a/application/views/scripts/items/search-form.php
+++ b/application/views/scripts/items/search-form.php
@@ -49,8 +49,7 @@ $formAttributes['method'] = 'GET';
         //[terms] = 'foobar'
         //etc
         foreach ($search as $i => $rows): ?>
-            <?php $index = $i + 1; // The index must start at 1 for accessible labels. ;?>
-            <div class="search-entry" id="search-row-<?php echo $index; ?>" aria-label="<?php echo __('Row %s', $index); ?>">
+            <div class="search-entry" id="search-row-<?php echo $i; ?>" aria-label="<?php echo __('Row %s', $i+1); ?>">
                 <div class="input advanced-search-joiner"> 
                     <span aria-hidden="true" class="visible-label"><?php echo __('Joiner'); ?></span>
                     <?php 
@@ -59,7 +58,7 @@ $formAttributes['method'] = 'GET';
                         @$rows['joiner'],
                         array(
                             'id' => null,
-                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $index . ' search-narrow-by-fields-joiner',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $i . ' search-narrow-by-fields-joiner',
                         ),
                         array(
                             'and' => __('AND'),
@@ -75,7 +74,7 @@ $formAttributes['method'] = 'GET';
                         "advanced[$i][element_id]",
                         @$rows['element_id'],
                         array(
-                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $index . ' search-narrow-by-fields-property',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $i . ' search-narrow-by-fields-property',
                             'id' => null,
                         ),
                         get_table_options('Element', null, array(
@@ -92,7 +91,7 @@ $formAttributes['method'] = 'GET';
                         "advanced[$i][type]",
                         @$rows['type'],
                         array(
-                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $index . ' search-narrow-by-fields-type',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $i . ' search-narrow-by-fields-type',
                             'id' => null,
                         ),
                         label_table_options(array(
@@ -115,13 +114,13 @@ $formAttributes['method'] = 'GET';
                         @$rows['terms'],
                         array(
                             'size' => '20',
-                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $index . ' search-narrow-by-fields-terms',
+                            'aria-labelledby' => 'search-narrow-by-fields-label search-row-' . $i . ' search-narrow-by-fields-terms',
                             'id' => null,
                         )
                     );
                     ?>
                 </div>
-                <button type="button" class="remove_search" disabled="disabled" style="display: none;" aria-labelledby="search-narrow-by-fields-label search-row-<?php echo $index; ?> search-narrow-by-fields-remove-field" title="<?php echo __('Remove field'); ?>"><?php echo __('Remove field'); ?></button>
+                <button type="button" class="remove_search" disabled="disabled" style="display: none;" aria-labelledby="search-narrow-by-fields-label search-row-<?php echo $i; ?> search-narrow-by-fields-remove-field" title="<?php echo __('Remove field'); ?>"><?php echo __('Remove field'); ?></button>
             </div>
         <?php endforeach; ?>
         </div>

--- a/application/views/scripts/javascripts/items-search.js
+++ b/application/views/scripts/javascripts/items-search.js
@@ -59,7 +59,15 @@ Omeka.Search = {};
                 removeAdvancedSearch(this);
             });
 
+            updateAdvancedSearchCount('#search-narrow-by-fields', '#search-narrow-by-field-alerts', '.search-entry');
             handleRemoveButtons();
+        }
+
+        function updateAdvancedSearchCount(fieldId, alertId, rowClass) {
+            var field =  $(fieldId);
+            var countSpan = $(alertId).find('.count');
+            var countValue = field.find(rowClass).length;
+            countSpan.text(countValue);
         }
 
         /**
@@ -70,6 +78,7 @@ Omeka.Search = {};
         function removeAdvancedSearch(button) {
             $(button).parent().remove();
             handleRemoveButtons();
+            updateAdvancedSearchCount('#search-narrow-by-fields', '#search-narrow-by-field-alerts', '.search-entry');
         }
 
         /**

--- a/application/views/scripts/javascripts/items-search.js
+++ b/application/views/scripts/javascripts/items-search.js
@@ -16,6 +16,12 @@ Omeka.Search = {};
 
         handleRemoveButtons();
 
+        function incrementScreenReaderLabels(attribute, element, index) {
+            var oldAttribute = element.attr(attribute);
+            var newAttribute = oldAttribute.replace(/\d+/, parseInt(index) + 1);
+            element.attr(attribute, newAttribute);
+        }
+
         /**
          * Callback for adding a new row of advanced search options.
          */
@@ -31,6 +37,7 @@ Omeka.Search = {};
 
             var inputs = div.find('input');
             var selects = div.find('select');
+            var rowName = div.attr('id');
 
             //Find the index of the last advanced search formlet and inc it
             //I.e. if there are two entries on the form, they should be named advanced[0], advanced[1], etc
@@ -40,10 +47,15 @@ Omeka.Search = {};
             var index = inputName.match(/advanced\[(\d+)\]/)[1];
             var newIndex = (parseInt(index, 10) + 1).toString();
 
-            //Reset the selects and inputs
+            //Reset the selects, inputs, and aria labels.
             inputs.val('');
             inputs.attr('name', function () {
                 return this.name.replace(/\d+/, newIndex);
+            });
+            incrementScreenReaderLabels('id', div, newIndex);
+            incrementScreenReaderLabels('aria-label', div, newIndex);
+            div.find('input, select, button').each(function() {
+                incrementScreenReaderLabels('aria-labelledby', $(this), newIndex);
             });
 
             selects.each(function () {


### PR DESCRIPTION
This provides the following accessibility improvements for the "Narrow by specific fields" group on the advanced item search form:

* More detailed aria labels
* Visible labels for the individual selects and text inputs
* Alerts to screen readers when field rows have been added or removed

These updates are only implemented for the public views at the moment. I was thinking we could mirror the changes for the admin side once this is approved and merged, though open to doing that within this pull request as well.