### PR TITLE
Minor deprecation warning fix in Zend_Ldap.

### DIFF
--- a/application/libraries/Zend/Ldap.php
+++ b/application/libraries/Zend/Ldap.php
@@ -811,7 +811,7 @@ class Zend_Ldap
 
         // Security check: remove null bytes in password
         // @see https://net.educause.edu/ir/library/pdf/csd4875.pdf
-        $password = str_replace("\0", '', $password);
+        $password = is_string($password) ? str_replace("\0", '', $password) : '';
 
         if ($username === null) {
             $username = $this->_getUsername();

--- a/application/libraries/Zend/Ldap.php
+++ b/application/libraries/Zend/Ldap.php
@@ -811,7 +811,7 @@ class Zend_Ldap
 
         // Security check: remove null bytes in password
         // @see https://net.educause.edu/ir/library/pdf/csd4875.pdf
-        $password = is_string($password) ? str_replace("\0", '', $password) : '';
+        $password = str_replace("\0", '', (string) $password);
 
         if ($username === null) {
             $username = $this->_getUsername();


### PR DESCRIPTION
This fixes a minor deprecation warning caused by Zend_Ldap attempting to str_replace() on null, for plugins adding LDAP support to Omeka Classic via the Zend libraries.