### PR TITLE
Fix PHP 8.2 deprecation warnings for dynamic properties.

### DIFF
--- a/application/libraries/Omeka/File/Ingest/Url.php
+++ b/application/libraries/Omeka/File/Ingest/Url.php
@@ -14,6 +14,15 @@
 class Omeka_File_Ingest_Url extends Omeka_File_Ingest_AbstractSourceIngest
 {
     /**
+     * HTTP client.
+     *
+     * Set by the _getHttpClient method.
+     *
+     * @var Zend_Http_Client
+     */
+    protected $_client = null;
+
+    /**
      * Return the original filename.
      *
      * @param array $fileInfo

--- a/application/libraries/Zend/Http/Client.php
+++ b/application/libraries/Zend/Http/Client.php
@@ -254,6 +254,15 @@ class Zend_Http_Client
     protected $redirectCounter = 0;
 
     /**
+     * Name of temporary stream
+     *
+     * Set by _openTempStream and used by the request method
+     *
+     * @var string
+     */
+    protected $_stream_name = null;
+
+    /**
      * Status for unmasking GET array params
      *
      * @var boolean


### PR DESCRIPTION
PHP 8.2 has deprecated dynamically created object properties. These two instances were found while using the insert_files_for_item global helper using the Url  transfer strategy. I've resolved the issue by simply adding the properties. I set the visibility to protected due to the names having leading underscores, but I could see setting them to public to ensure that there would be no broken code. I could not find any instance of the properties being used by any other code within Omeka, but I suppose there is a very slight chance a plugin could expect the side effect of the properties being created.