### PR TITLE
Add iframe allowfullscreen attribute to HTML purifier

### DIFF
--- a/application/libraries/htmlpurifier/HTMLPurifier/HTMLModule/Iframe.php
+++ b/application/libraries/htmlpurifier/HTMLPurifier/HTMLModule/Iframe.php
@@ -43,6 +43,7 @@ class HTMLPurifier_HTMLModule_Iframe extends HTMLPurifier_HTMLModule
                 'longdesc' => 'URI',
                 'marginheight' => 'Pixels',
                 'marginwidth' => 'Pixels',
+                'allowfullscreen' => 'Bool',
             )
         );
     }


### PR DESCRIPTION
This prevents the `allowfullscreen` attribute from being erased in `<iframe>` tags, which is needed for many types of embedded viewers and players.

Resolves #942