### PR TITLE
Offer to set the option to sign an e-mail from whom

### DIFF
--- a/application/controllers/UsersController.php
+++ b/application/controllers/UsersController.php
@@ -98,6 +98,8 @@ class UsersController extends Omeka_Controller_AbstractActionController
     private function _sendResetPasswordEmail($toEmail, $activationCode)
     {
         $siteTitle = get_option('site_title');
+        $emailFrom = get_option('email_from');
+        $from = get_option('administrator_email');
 
         $mail = new Zend_Mail('UTF-8');
         $mail->addTo($toEmail);
@@ -114,7 +116,10 @@ class UsersController extends Omeka_Controller_AbstractActionController
         $body .= __("%s Administrator", $siteTitle);
 
         $mail->setBodyText($body);
-        $mail->setFrom(get_option('administrator_email'), __("%s Administrator", $siteTitle));
+        if(!empty($emailFrom))
+            $mail->setFrom($from, __("%s Administrator", $emailFrom));
+        else
+            $mail->setFrom($from, __("%s Administrator", $siteTitle));
         $mail->setSubject(__("[%s] Reset Your Password", $siteTitle));
 
         $mail->send();
@@ -384,6 +389,7 @@ class UsersController extends Omeka_Controller_AbstractActionController
         $ua->save();
         // send the user an email telling them about their new user account
         $siteTitle = get_option('site_title');
+        $emailFrom = get_option('email_from');
         $from = get_option('administrator_email');
         $body = __('Welcome!')
                     ."\n\n"
@@ -394,7 +400,10 @@ class UsersController extends Omeka_Controller_AbstractActionController
 
         $mail = new Zend_Mail('UTF-8');
         $mail->setBodyText($body);
-        $mail->setFrom($from, "$siteTitle Administrator");
+        if(!empty($emailFrom))
+            $mail->setFrom($from, __("%s Administrator", $emailFrom));
+        else
+            $mail->setFrom($from, __("%s Administrator", $siteTitle));
         $mail->addTo($user->email, $user->name);
         $mail->setSubject($subject);
         $mail->addHeader('X-Mailer', 'PHP/' . phpversion());

--- a/application/forms/GeneralSettings.php
+++ b/application/forms/GeneralSettings.php
@@ -41,6 +41,10 @@ class Omeka_Form_GeneralSettings extends Omeka_Form
             'label' => __('Site Author Information')
         ));
 
+        $this->addElement('text', 'email_from', array(
+            'label' => __('Email signature from whom')
+        ));
+
         $this->addElement('text', 'tag_delimiter', array(
             'label' => __('Tag Delimiter'),
             'description' => __('Separate tags using this character or string. Be careful when changing this setting. You run the risk of splitting tags that contain the old delimiter.'),
@@ -65,7 +69,7 @@ class Omeka_Form_GeneralSettings extends Omeka_Form
 
         $this->addDisplayGroup(
             array('administrator_email', 'site_title', 'description',
-                  'copyright', 'author', 'tag_delimiter', 'path_to_convert'),
+                  'copyright', 'author', 'email_from', 'tag_delimiter', 'path_to_convert'),
             'site_settings', array('legend' => __('General Settings')));
     }
 }

--- a/application/forms/GeneralSettings.php
+++ b/application/forms/GeneralSettings.php
@@ -42,7 +42,8 @@ class Omeka_Form_GeneralSettings extends Omeka_Form
         ));
 
         $this->addElement('text', 'email_from', array(
-            'label' => __('Email signature from whom')
+            'label' => __('Email signature from whom'),
+            'description' => __('This field is used for the signature of e-mails from whom, fill in as needed, if not filled in the signature from who uses the site header.')
         ));
 
         $this->addElement('text', 'tag_delimiter', array(


### PR DESCRIPTION
Offer for update GeneralSettings.php
Added the option to sign an e-mail from whom.
Offer for update UsersController.php
Added a condition to use an email signature from who if the option is set.

The reason for this proposal was the problem of a broken signature of an e-mail from whom.
Maybe it will be useful to someone, because it turned out to be necessary for us due to the fact that the name of the site cannot be shortened.

When using a long signature in Cyrillic from the site title.

![msg1](https://github.com/omeka/Omeka/assets/26433886/909a62a8-df4d-4a53-8069-84b1ba7800be)

When using a short signature from a custom field.

![msg2](https://github.com/omeka/Omeka/assets/26433886/55241843-8118-4e1a-9cf8-e52f78e59da2)

When using a long signature in Latin from the site title.

![msg3](https://github.com/omeka/Omeka/assets/26433886/48387b53-57de-4bf6-85f9-aca7dc21ef9f)
