### PR TITLE
Misaligned element texts in admin theme

### DIFF
--- a/admin/themes/default/css/sass/pages/_items.scss
+++ b/admin/themes/default/css/sass/pages/_items.scss
@@ -241,6 +241,10 @@
         height: 0px;
         margin-bottom: 0;
     }
+    
+    @media (max-width: 1440px) {
+      .element .element-text{
+        margin-left: 10px; } }
 
 .element-text p {
     word-wrap: break-word;

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -2226,6 +2226,10 @@ ul.details {
 .element .element-text:last-of-type:after {
   height: 0px;
   margin-bottom: 0; }
+  
+@media (max-width: 1440px) {
+  .element .element-text{
+    margin-left: 10px; } }
 
 .element-text p {
   word-wrap: break-word;


### PR DESCRIPTION
**NOTE**: I did not compile the updated Sass file because I don't have that set up right now. Instead I just manually added new styles to `style.css`. But the necessary change is small and easy to implement outside this PR if that's preferred.

The screenshot below is an example of what this change addresses. Basically, all element texts after the first one are misaligned when the viewport is smaller than 1440px. I think it's been like this for quite a while.

<img width="778" alt="Screenshot 2024-08-29 at 10 38 15 AM" src="https://github.com/user-attachments/assets/b502fae2-5147-454b-8052-7d24413e01f1">
