### PR TITLE
Provide alt text configuration options for images.

### DIFF
--- a/admin/themes/default/collections/browse.php
+++ b/admin/themes/default/collections/browse.php
@@ -42,7 +42,7 @@ echo flash();
                     <?php foreach (loop('Collection') as $collection): ?>
                     <tr class="collection<?php if(++$key%2==1) echo ' odd'; else echo ' even'; ?>">
                         <td class="title<?php if ($collection->featured) { echo ' featured';} ?>">
-                            <?php if ($collectionImage = record_image('collection', 'square_thumbnail', array('role' => 'presentation'))): ?>
+                            <?php if ($collectionImage = record_image('collection', 'square_thumbnail')): ?>
                                 <?php echo link_to_collection($collectionImage, array('class' => 'image')); ?>
                             <?php endif; ?>
 

--- a/admin/themes/default/files/edit.php
+++ b/admin/themes/default/files/edit.php
@@ -38,7 +38,7 @@ echo flash();
             <?php endif; ?>
             <?php fire_plugin_hook("admin_files_panel_buttons", array('view'=>$this, 'record'=>$file)); ?>
             <div id="alt-text-form" class="field">
-                <?php echo $this->formLabel('collection-id', __('Alt Text'));?>
+                <?php echo $this->formLabel('file-alt-text', __('Alt Text'));?>
                 <div class="inputs">
                     <p class="explanation"><?php echo __('Provide a brief description of visual files to screen reader users.'); ?></p>
                     <?php

--- a/admin/themes/default/files/edit.php
+++ b/admin/themes/default/files/edit.php
@@ -37,6 +37,22 @@ echo flash();
                 <?php echo link_to($file, 'delete-confirm', __('Delete'), array('class' => 'big red button delete-confirm')); ?>
             <?php endif; ?>
             <?php fire_plugin_hook("admin_files_panel_buttons", array('view'=>$this, 'record'=>$file)); ?>
+            <div id="alt-text-form" class="field">
+                <?php echo $this->formLabel('collection-id', __('Alt Text'));?>
+                <div class="inputs">
+                    <p class="explanation"><?php echo __('Provide a brief description of visual files to screen reader users.'); ?></p>
+                    <?php
+                        echo $this->formTextarea(
+                            'alt_text',
+                            $file->alt_text,
+                            array(
+                                'id' => 'file-alt-text',
+                                'rows' => '5'
+                            )
+                        );
+                    ?>
+                </div>
+            </div>
             <?php fire_plugin_hook("admin_files_panel_fields", array('view'=>$this, 'record'=>$file)); ?>
         </div>
     </section>

--- a/admin/themes/default/files/show.php
+++ b/admin/themes/default/files/show.php
@@ -39,7 +39,7 @@ echo flash();
     <div id="file-alt-text" class="panel">
         <h4><?php echo __('Alt Text'); ?></h4>
         <p>
-            <?php echo html_escape(metadata($file, 'alt_text')); ?>
+            <?php echo metadata($file, 'alt_text'); ?>
         </p>
     </div>
 

--- a/admin/themes/default/files/show.php
+++ b/admin/themes/default/files/show.php
@@ -31,10 +31,18 @@ echo flash();
         <?php endif; ?>
     </div>
     
-    <div id="item-metadata" class="panel">
+    <div id="file-item" class="panel">
         <h4><?php echo __('Item'); ?></h4>
         <p><?php echo link_to_item(null, array(), 'show', $file->getItem()); ?></p>
     </div>
+
+    <div id="file-alt-text" class="panel">
+        <h4><?php echo __('Alt Text'); ?></h4>
+        <p>
+            <?php echo $file->getAltText(); ?>
+        </p>
+    </div>
+
 
     <div id="file-links" class="panel">
         <h4><?php echo __('Direct Links'); ?></h4>

--- a/admin/themes/default/files/show.php
+++ b/admin/themes/default/files/show.php
@@ -39,7 +39,7 @@ echo flash();
     <div id="file-alt-text" class="panel">
         <h4><?php echo __('Alt Text'); ?></h4>
         <p>
-            <?php echo $file->getAltText(); ?>
+            <?php echo html_escape(metadata($file, 'alt_text')); ?>
         </p>
     </div>
 

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -72,7 +72,7 @@ echo item_search_filters();
                     <td class="item-info">
 
                         <?php if (metadata('item', 'has files')): ?>
-                        <?php echo link_to_item(item_image('square_thumbnail', null, 0, $item), array('class' => 'item-thumbnail'), 'show', $item); ?>
+                        <?php echo link_to_item(item_image('square_thumbnail', array(), 0, $item), array('class' => 'item-thumbnail'), 'show', $item); ?>
                         <?php endif; ?>
 
                         <span class="title">

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -72,7 +72,7 @@ echo item_search_filters();
                     <td class="item-info">
 
                         <?php if (metadata('item', 'has files')): ?>
-                        <?php echo link_to_item(item_image('square_thumbnail', array('role' => 'presentation'), 0, $item), array('class' => 'item-thumbnail'), 'show', $item); ?>
+                        <?php echo link_to_item(item_image('square_thumbnail', null, 0, $item), array('class' => 'item-thumbnail'), 'show', $item); ?>
                         <?php endif; ?>
 
                         <span class="title">

--- a/application/forms/AppearanceSettings.php
+++ b/application/forms/AppearanceSettings.php
@@ -76,6 +76,31 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
             'class' => 'checkbox',
         ));
 
+        $db = get_db();
+        $sql = "
+        SELECT es.name AS element_set_name, e.id AS element_id, e.name AS element_name
+        FROM {$db->ElementSet} es 
+        JOIN {$db->Element} e ON es.id = e.element_set_id 
+        WHERE es.record_type IS NULL OR es.record_type = 'File' 
+        ORDER BY es.name, e.name";
+        $legacyElementSetNames = array('Omeka Image File', 'Omeka Video File', 'Omeka Legacy File');
+        $elements = $db->fetchAll($sql);
+        $elementOptions = array('' => __('Select Below'));
+        foreach ($elements as $element) {
+            $optGroup = __($element['element_set_name']);
+            if (array_search($optGroup, $legacyElementSetNames) !== false) {
+                continue;
+            }
+            $value = __($element['element_name']);
+            $elementOptions[$optGroup]["$optGroup,$value"] = $value;
+        }
+
+        $this->addElement('select', 'file_alt_text_element', array(
+            'label' => __('File Alt Text Element'),
+            'description' => __('Element to use in describing visual files to screen reader users.'),
+            'multiOptions' => $elementOptions
+        ));
+
         $adminThemes = Theme::getAllAdminThemes();
         if (count($adminThemes) > 1 && is_allowed('Themes', 'edit')) {
             foreach ($adminThemes as &$theme) {
@@ -102,7 +127,7 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
         $this->addDisplayGroup(
             array(
                 'use_square_thumbnail', 'link_to_file_metadata', 'per_page_admin', 'per_page_public',
-                'show_empty_elements', 'show_element_set_headings',
+                'show_empty_elements', 'show_element_set_headings', 'file_alt_text_element',
             ),
             'display-settings', array('legend' => __('Display Settings'))
         );

--- a/application/forms/AppearanceSettings.php
+++ b/application/forms/AppearanceSettings.php
@@ -76,29 +76,14 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
             'class' => 'checkbox',
         ));
 
-        $db = get_db();
-        $sql = "
-        SELECT es.name AS element_set_name, e.id AS element_id, e.name AS element_name
-        FROM {$db->ElementSet} es 
-        JOIN {$db->Element} e ON es.id = e.element_set_id 
-        WHERE es.record_type IS NULL OR es.record_type = 'File' 
-        ORDER BY es.name, e.name";
-        $legacyElementSetNames = array('Omeka Image File', 'Omeka Video File', 'Omeka Legacy File');
-        $elements = $db->fetchAll($sql);
-        $elementOptions = array('' => __('Select Below'));
-        foreach ($elements as $element) {
-            $optGroup = __($element['element_set_name']);
-            if (array_search($optGroup, $legacyElementSetNames) !== false) {
-                continue;
-            }
-            $value = __($element['element_name']);
-            $elementOptions[$optGroup]["$optGroup,$value"] = $value;
-        }
 
         $this->addElement('select', 'file_alt_text_element', array(
             'label' => __('File Alt Text Element'),
             'description' => __('Default element to use in describing visual files to screen reader users via the image tag\'s alt attribute. This can be overridden using the file form\'s "Alt Text" field.'),
-            'multiOptions' => $elementOptions
+            'multiOptions' => get_table_options('Element', null, array(
+                'record_types' => array('File', 'All'),
+                'sort' => 'orderBySet')
+            )
         ));
 
         $adminThemes = Theme::getAllAdminThemes();

--- a/application/forms/AppearanceSettings.php
+++ b/application/forms/AppearanceSettings.php
@@ -97,7 +97,7 @@ class Omeka_Form_AppearanceSettings extends Omeka_Form
 
         $this->addElement('select', 'file_alt_text_element', array(
             'label' => __('File Alt Text Element'),
-            'description' => __('Element to use in describing visual files to screen reader users.'),
+            'description' => __('Default element to use in describing visual files to screen reader users via the image tag\'s alt attribute. This can be overridden using the file form\'s "Alt Text" field.'),
             'multiOptions' => $elementOptions
         ));
 

--- a/application/migrations/20240917160000_addFileAltText.php
+++ b/application/migrations/20240917160000_addFileAltText.php
@@ -15,6 +15,6 @@ class addFileAltText extends Omeka_Db_Migration_AbstractMigration
 {
     public function up()
     {
-        $this->db->query("ALTER TABLE {$this->db->File} ADD `alt_text` mediumtext collate utf8_unicode_ci NOT NULL");
+        $this->db->query("ALTER TABLE {$this->db->File} ADD `alt_text` text collate utf8_unicode_ci");
     }
 }

--- a/application/migrations/20240917160000_addFileAltText.php
+++ b/application/migrations/20240917160000_addFileAltText.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Omeka
+ *
+ * @copyright Copyright 2007-2022 Roy Rosenzweig Center for History and New Media
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GNU GPLv3
+ */
+
+/**
+ * Add alt text column to file table
+ *
+ * @package Omeka\Db\Migration
+ */
+class addFileAltText extends Omeka_Db_Migration_AbstractMigration
+{
+    public function up()
+    {
+        $this->db->query("ALTER TABLE {$this->db->File} ADD `alt_text` mediumtext collate utf8_unicode_ci NOT NULL");
+    }
+}

--- a/application/migrations/20240917160000_addFileAltText.php
+++ b/application/migrations/20240917160000_addFileAltText.php
@@ -15,6 +15,6 @@ class addFileAltText extends Omeka_Db_Migration_AbstractMigration
 {
     public function up()
     {
-        $this->db->query("ALTER TABLE {$this->db->File} ADD `alt_text` text collate utf8_unicode_ci");
+        $this->db->query("ALTER TABLE {$this->db->File} ADD `alt_text` mediumtext collate utf8_unicode_ci");
     }
 }

--- a/application/models/File.php
+++ b/application/models/File.php
@@ -156,6 +156,8 @@ class File extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
                 return $this->getDisplayTitle($this->original_filename);
             case 'rich_title':
                 return $this->getRichTitle(html_escape($this->original_filename));
+            case 'alt_text':
+                return $this->getAltText();
             default:
                 return parent::getProperty($property);
         }

--- a/application/models/File.php
+++ b/application/models/File.php
@@ -176,6 +176,7 @@ class File extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
                 $fileAltTextElementText = $fileAltTextElementTexts[0]->text;
                 if ($fileAltTextElementTexts[0]->html) {
                     $fileAltTextElementText = strip_formatting($fileAltTextElementText);
+                    $fileAltTextElementText = html_entity_decode($fileAltTextElementText, ENT_QUOTES, 'UTF-8');
                 }
                 return trim($fileAltTextElementText);
             }

--- a/application/models/File.php
+++ b/application/models/File.php
@@ -171,7 +171,7 @@ class File extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
             $fileAltTextElementText = metadata($this, explode(',',$fileAltTextElement));
             return strip_formatting($fileAltTextElementText);
         } else {
-            return '""';
+            return '';
         }
     }
 

--- a/application/models/File.php
+++ b/application/models/File.php
@@ -115,6 +115,13 @@ class File extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
     public $metadata;
 
     /**
+     * Alt text to use for file display.
+     *
+     * @var string
+     */
+    public $alt_text;
+
+    /**
      * Folder paths for each type of files/derivatives.
      *
      * @var array
@@ -151,6 +158,20 @@ class File extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
                 return $this->getRichTitle(html_escape($this->original_filename));
             default:
                 return parent::getProperty($property);
+        }
+    }
+
+    public function getAltText() {
+        $fileCustomAltText = $this->alt_text;
+        $fileAltTextElement = get_option('file_alt_text_element');
+
+        if ($fileCustomAltText) {
+            return $fileCustomAltText;
+        } elseif ($fileAltTextElement) {
+            $fileAltTextElementText = metadata($this, explode(',',$fileAltTextElement));
+            return strip_formatting($fileAltTextElementText);
+        } else {
+            return '""';
         }
     }
 

--- a/application/models/File.php
+++ b/application/models/File.php
@@ -165,13 +165,20 @@ class File extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
 
     public function getAltText() {
         $fileCustomAltText = $this->alt_text;
-        $fileAltTextElement = get_option('file_alt_text_element');
+        $fileAltTextElementId = get_option('file_alt_text_element');
 
         if ($fileCustomAltText) {
             return $fileCustomAltText;
-        } elseif ($fileAltTextElement) {
-            $fileAltTextElementText = metadata($this, explode(',',$fileAltTextElement));
-            return strip_formatting($fileAltTextElementText);
+        } elseif ($fileAltTextElementId) {
+            $fileAltTextElement = $this->getElementById($fileAltTextElementId);
+            $fileAltTextElementTexts = $this->getElementTextsByRecord($fileAltTextElement);
+            if ($fileAltTextElementTexts) {
+                $fileAltTextElementText = $fileAltTextElementTexts[0]->text;
+                if ($fileAltTextElementTexts[0]->html) {
+                    $fileAltTextElementText = strip_formatting($fileAltTextElementText);
+                }
+                return trim($fileAltTextElementText);
+            }
         } else {
             return '';
         }

--- a/application/schema/files.sql
+++ b/application/schema/files.sql
@@ -13,6 +13,7 @@ CREATE TABLE IF NOT EXISTS `%PREFIX%files` (
   `added` timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
   `stored` tinyint(1) NOT NULL default '0',
   `metadata` mediumtext collate utf8_unicode_ci NOT NULL,
+  `alt_text` mediumtext collate utf8_unicode_ci NOT NULL,
   PRIMARY KEY  (`id`),
   KEY `item_id` (`item_id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/application/schema/files.sql
+++ b/application/schema/files.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS `%PREFIX%files` (
   `added` timestamp NOT NULL DEFAULT '2000-01-01 00:00:00',
   `stored` tinyint(1) NOT NULL default '0',
   `metadata` mediumtext collate utf8_unicode_ci NOT NULL,
-  `alt_text` mediumtext collate utf8_unicode_ci NOT NULL,
+  `alt_text` mediumtext collate utf8_unicode_ci,
   PRIMARY KEY  (`id`),
   KEY `item_id` (`item_id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/application/views/helpers/FileMarkup.php
+++ b/application/views/helpers/FileMarkup.php
@@ -636,18 +636,10 @@ class Omeka_View_Helper_FileMarkup extends Zend_View_Helper_Abstract
         $alt = '';
         if (isset($attrs['alt'])) {
             $alt = $attrs['alt'];
-        } elseif ($fileTitle = metadata($file, 'display title', array('no_escape' => true))) {
-            $alt = $fileTitle;
+        } else {
+            $alt = $file->getAltText();
         }
         $attrs['alt'] = $alt;
-
-        $title = '';
-        if (isset($attrs['title'])) {
-            $title = $attrs['title'];
-        } else {
-            $title = $alt;
-        }
-        $attrs['title'] = $title;
 
         $attrs = apply_filters('image_tag_attributes', $attrs, array(
             'record' => $record,

--- a/application/views/scripts/items/browse.php
+++ b/application/views/scripts/items/browse.php
@@ -32,7 +32,7 @@ $sortLinks[__('Date Added')] = 'added';
     <div class="item-meta">
     <?php if (metadata('item', 'has files')): ?>
     <div class="item-img">
-        <?php echo link_to_item(item_image(null, array('role' => 'presentation'))); ?>
+        <?php echo link_to_item(item_image(null)); ?>
     </div>
     <?php endif; ?>
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -8,7 +8,7 @@
  */
 
 // Define the current version of Omeka.
-define('OMEKA_VERSION', '3.2-dev3');
+define('OMEKA_VERSION', '3.2-dev4');
 
 // Define the application environment.
 if (!defined('APPLICATION_ENV')) {


### PR DESCRIPTION
* Within the Appearance Settings, users can select an element that can provide alt text for files.
* Users can also write alt text via a new field on the file edit form. This field will override alt text provided by file metadata.
* Images use a blank alt by default.
* File markup no longer provides titles by default, nor populate titles using the alt attribute.
* Browse views no longer assign "presentation" roles to the record images.