### PR TITLE
Prevent undefined array key access in FormInput helper

### DIFF
--- a/application/views/helpers/FormInput.php
+++ b/application/views/helpers/FormInput.php
@@ -39,7 +39,7 @@ class Omeka_View_Helper_FormInput extends Zend_View_Helper_FormElement
         }
 
         $type = 'text';
-        if ($attribs['type']) {
+        if (isset($attribs['type'])) {
             $type = $attribs['type'];
             unset($attribs['type']);
         }


### PR DESCRIPTION
Hi, I wrote some plugins the past days and used the `formInput()` function in my config forms. All occurrences throwing following warning:
`[php:warn] [pid 69748] [client 172.24.0.1:55254] PHP Warning:  Undefined array key "type" in /app/application/views/helpers/FormInput.php on line 42, referer: http://localhost:8202/nikephoros/admin/plugins
`

If we call `formInput()` without an attribute parameter it defaults it to `null`. But later in L42 we accessing that attribute without checking if its set:
https://github.com/omeka/Omeka/blob/56c7f087f2311f8f23adbfac6e7ac7367fb308c2/application/views/helpers/FormInput.php#L41-L45

This PR adds a simple 'isset()' check, so we do not access a unset variable.
