### PR TITLE
fix potential lightgallery markup conflict

### DIFF
--- a/application/views/helpers/LightGallery.php
+++ b/application/views/helpers/LightGallery.php
@@ -18,7 +18,7 @@ class Omeka_View_Helper_LightGallery extends Zend_View_Helper_Abstract
     {
         $sortedFiles = $this->_prepareFiles($files);
         $html = '';
-        $html .= '<div id="itemfiles" class="lightgallery">';
+        $html .= '<div id="omeka-lightgallery" class="lightgallery">';
         $captionOption = get_theme_option('lightgallery_caption');
 
         foreach ($sortedFiles['gallery'] as $galleryEntry) {

--- a/application/views/scripts/css/lightgallery.css
+++ b/application/views/scripts/css/lightgallery.css
@@ -1,4 +1,4 @@
-#itemfiles.lightgallery {
+#omeka-lightgallery.lightgallery {
     overflow: hidden;
     height: 50vh;
     margin-bottom: 1rem;

--- a/application/views/scripts/javascripts/lightgallery-init.js
+++ b/application/views/scripts/javascripts/lightgallery-init.js
@@ -1,6 +1,6 @@
 (function($) {
     $(document).ready(function() {
-        const lgContainer = document.getElementById('itemfiles');
+        const lgContainer = document.getElementById('omeka-lightgallery');
 
         const inlineGallery = lightGallery(lgContainer, {
             licenseKey: '76E9AA35-CDB54382-B1A52890-683C953F',


### PR DESCRIPTION
This PR fixes an issue where using a plugin filter to add support for [Omeka's standard LightGallery](https://omeka.readthedocs.io/en/latest/Reference/libraries/globals/lightgallery.html) cannot work in themes that wrap their default media markup in an `#itemfiles` container (this is the case for the default templates – and thus Seasons – as well as Rhythm, Minimalist, Freedom, Thanks Roy, and Emiglio). This also fixes a potential validation issue since those themes would also have a duplicate `#itemfiles` div. All that's changed here is that the default markup now uses a more specific id that is less likely to have conflicts. This minor change does not appear to manifest in any CSS selector issues with  themes that already use LightGallery by default (Center Row, The Daily).

## Update
There actually is an issue with the Big Picture theme that would need to be addressed in a future update.