### PR TITLE
Action link alignment fix

### DIFF
--- a/admin/themes/default/css/sass/components/_tables.scss
+++ b/admin/themes/default/css/sass/components/_tables.scss
@@ -132,6 +132,7 @@ td {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
+    gap: $spacing-s;
 
     @include screen-xs {
         clear: both;
@@ -143,7 +144,7 @@ td {
     }
 
     li {
-        display: inline-block;
+        display: inline-flex;
 
         .spacer {
             display: inline-block;
@@ -155,13 +156,8 @@ td {
             margin-right: 3px;
 
             @include screen-xs {
-                content: '';
-                margin: 0;
+                display: none;
             }
-        }
-
-        @include screen-xs {
-            margin-bottom: $spacing-s;
         }
 
         &:last-child:after {

--- a/admin/themes/default/css/sass/components/_tables.scss
+++ b/admin/themes/default/css/sass/components/_tables.scss
@@ -132,7 +132,6 @@ td {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
-    gap: $spacing-s;
 
     @include screen-xs {
         clear: both;
@@ -146,13 +145,9 @@ td {
     li {
         display: inline-flex;
 
-        .spacer {
-            display: inline-block;
-        }
-
-        .spacer:after {
+        &:not(:last-child):after {
             content: '\00b7' / '';
-            margin-right: 5px;
+            margin: 0 5px;
 
             @include screen-xs {
                 display: none;

--- a/admin/themes/default/css/sass/components/_tables.scss
+++ b/admin/themes/default/css/sass/components/_tables.scss
@@ -129,6 +129,9 @@ td {
     list-style-type: none;
     margin: 0;
     padding: 0;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
 
     @include screen-xs {
         clear: both;
@@ -147,7 +150,7 @@ td {
         }
 
         .spacer:after {
-            content: ' \00b7';
+            content: ' \00b7' \ '';
             margin-left: 3px;
             margin-right: 3px;
 

--- a/admin/themes/default/css/sass/components/_tables.scss
+++ b/admin/themes/default/css/sass/components/_tables.scss
@@ -151,9 +151,8 @@ td {
         }
 
         .spacer:after {
-            content: ' \00b7' \ '';
-            margin-left: 3px;
-            margin-right: 3px;
+            content: '\00b7' / '';
+            margin-right: 5px;
 
             @include screen-xs {
                 display: none;

--- a/admin/themes/default/css/sass/pages/_items.scss
+++ b/admin/themes/default/css/sass/pages/_items.scss
@@ -77,7 +77,7 @@
         @include button;
         @include small;
         @include blue;
-        margin-bottom: 0;
+        margin: 0;
     }
     
     .browse .action-links a.delete-confirm {

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -2176,9 +2176,8 @@ td {
   display: inline-block;
 }
 .action-links li .spacer:after {
-  content: " ·" \  "";
-  margin-left: 3px;
-  margin-right: 3px;
+  content: "·"/"";
+  margin-right: 5px;
 }
 @media (max-width: 767px) {
   .action-links li .spacer:after {

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -2158,6 +2158,7 @@ td {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  gap: 5px;
 }
 @media (max-width: 767px) {
   .action-links {
@@ -2169,7 +2170,7 @@ td {
   color: #003576;
 }
 .action-links li {
-  display: inline-block;
+  display: inline-flex;
 }
 .action-links li .spacer {
   display: inline-block;
@@ -2181,13 +2182,7 @@ td {
 }
 @media (max-width: 767px) {
   .action-links li .spacer:after {
-    content: "";
-    margin: 0;
-  }
-}
-@media (max-width: 767px) {
-  .action-links li {
-    margin-bottom: 5px;
+    display: none;
   }
 }
 .action-links li:last-child:after {
@@ -2588,7 +2583,7 @@ ul.details li:last-child {
     color: #003576;
     background: #EEF3FA;
     border: 1px solid rgba(0, 53, 118, 0.25);
-    margin-bottom: 0;
+    margin: 0;
   }
   .browse .action-links a:hover, .browse .action-links a:focus {
     border-color: rgba(35, 35, 35, 0.65);

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -2155,6 +2155,9 @@ td {
   list-style-type: none;
   margin: 0;
   padding: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
 }
 @media (max-width: 767px) {
   .action-links {
@@ -2172,7 +2175,7 @@ td {
   display: inline-block;
 }
 .action-links li .spacer:after {
-  content: " ·";
+  content: " ·" \  "";
   margin-left: 3px;
   margin-right: 3px;
 }

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -2158,7 +2158,6 @@ td {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 5px;
 }
 @media (max-width: 767px) {
   .action-links {
@@ -2172,15 +2171,12 @@ td {
 .action-links li {
   display: inline-flex;
 }
-.action-links li .spacer {
-  display: inline-block;
-}
-.action-links li .spacer:after {
+.action-links li:not(:last-child):after {
   content: "·"/"";
-  margin-right: 5px;
+  margin: 0 5px;
 }
 @media (max-width: 767px) {
-  .action-links li .spacer:after {
+  .action-links li:not(:last-child):after {
     display: none;
   }
 }

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -92,14 +92,12 @@ echo item_search_filters();
                         <ul class="action-links group">
                             <?php if (is_allowed($item, 'edit')): ?>
                             <li>
-                                <span class="spacer" aria-hidden="true"></span>
                                 <?php echo link_to_item(__('Edit'), ['class' => 'edit'], 'edit'); ?>
                             </li>
                             <?php endif; ?>
 
                             <?php if (is_allowed($item, 'delete')): ?>
                             <li>
-                                <span class="spacer" aria-hidden="true"></span>
                                 <?php echo link_to_item(__('Delete'), ['class' => 'delete-confirm'], 'delete-confirm'); ?>
                             </li>
                             <?php endif; ?>


### PR DESCRIPTION
This fixes #1090, where older browsers were rendering some browse action links out of vertical alignment with the others. It uses flexbox to keep them vertically centered, as opposed to the finicky `inline-block` and `vertical align` combo.