### PR TITLE
Populate landmark aria-labels across admin

### DIFF
--- a/admin/themes/default/collections/browse.php
+++ b/admin/themes/default/collections/browse.php
@@ -6,7 +6,7 @@ echo flash();
 ?>
 
 <?php if (total_records('Collection') > 0): ?>
-    <?php echo pagination_links(['attributes' => ['aria-label' => __('Top pagination')]]); ?>
+    <?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
     <?php if (is_allowed('Collections', 'add')): ?>
         <a href="<?php echo html_escape(url('collections/add')); ?>" class="green button">
             <?php echo __('Add a Collection'); ?>
@@ -85,7 +85,7 @@ echo flash();
             </table>
         </div>
 
-        <?php echo pagination_links(['attributes' => ['aria-label' => __('Bottom pagination')]]); ?>
+        <?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
         <?php if (is_allowed('Collections', 'add')): ?>
             <a href="<?php echo html_escape(url('collections/add')); ?>" class="green button"><?php echo __('Add a Collection'); ?></a>
         <?php endif; ?>

--- a/admin/themes/default/common/appearance-nav.php
+++ b/admin/themes/default/common/appearance-nav.php
@@ -1,4 +1,4 @@
-<nav id="section-nav" class="navigation vertical" role="navigation">
+<nav id="section-nav" class="navigation vertical" role="navigation" aria-label="<?php echo __('Appearance'); ?>">
 <?php
     $navArray = [
         [

--- a/admin/themes/default/common/content-nav.php
+++ b/admin/themes/default/common/content-nav.php
@@ -1,4 +1,4 @@
-<nav id="content-nav" class="two columns" role="navigation" aria-label="<?php echo __('Main Menu'); ?>">
+<nav id="content-nav" class="two columns" role="navigation" aria-label="<?php echo __('Content'); ?>">
 	<button type="button" id="content-nav-toggle" class="mobile-menu" data-target=".navigation" aria-expanded="false" title="<?php echo __('Main Menu'); ?>"><span class="sr-only"><?php echo __('Main Menu'); ?> <?php echo __('Current Page'); ?> </span><?php echo $title; ?></button>
     <?php
         $mainNav = [

--- a/admin/themes/default/common/header.php
+++ b/admin/themes/default/common/header.php
@@ -34,7 +34,7 @@
 
 <?php echo body_tag(['id' => @$bodyid, 'class' => @$bodyclass]); ?>
 
-<header role="banner">
+<header>
     <a href="#content" id="skipnav"><?php echo __('Skip to main content'); ?></a>
     <?php fire_plugin_hook('admin_header_top', ['view'=>$this]); ?>
     <div id="site-title" class="two columns">
@@ -42,7 +42,7 @@
     </div>
 	<button id="mobile-navbar-toggle" class="mobile-menu" data-target="#global-nav" title="<?php echo __('Admin'); ?>" aria-label="<?php echo __('Admin'); ?>" aria-expanded="false"><span class="admin-icon" aria-role="hidden"></span></button>
 
-    <nav id="global-nav">
+    <nav id="global-nav" aria-label="<?php echo __('Admin'); ?>">
         <?php echo common('global-nav'); ?>
         
         <ul id="user-nav">

--- a/admin/themes/default/item-types/browse.php
+++ b/admin/themes/default/item-types/browse.php
@@ -9,7 +9,7 @@ echo flash();
 <?php echo link_to('item-types', 'add', __('Add an Item Type'), ['class'=>'add green button']); ?>
 <?php endif ?>
 
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Top pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 
 <p class="without-item-type">
     <?php if ($totalItemsWithoutType):
@@ -54,7 +54,7 @@ echo flash();
 <?php echo link_to('item-types', 'add', __('Add an Item Type'), ['class'=>'add green button']); ?>
 <?php endif ?>
 
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Bottom pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 
 <p class="without-item-type"><?php echo $withoutTypeMessage; ?></p>
 

--- a/admin/themes/default/items/browse.php
+++ b/admin/themes/default/items/browse.php
@@ -12,7 +12,7 @@ echo item_search_filters();
 ?>
 
 <?php if ($total_results): ?>
-    <?php echo pagination_links(['attributes' => ['aria-label' => __('Top pagination')]]); ?>
+    <?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
     <?php if (is_allowed('Items', 'add')): ?>
     <a href="<?php echo html_escape(url('items/add')); ?>" class="add full-width-mobile button green"><?php echo __('Add an Item'); ?></a>
     <?php endif; ?>
@@ -149,7 +149,7 @@ echo item_search_filters();
         </div>
     </form>
 
-    <?php echo pagination_links(['attributes' => ['aria-label' => __('Bottom pagination')]]); ?>
+    <?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
     <?php if (is_allowed('Items', 'add')): ?>
     <a href="<?php echo html_escape(url('items/add')); ?>" class="add full-width-mobile button green"><?php echo __('Add an Item'); ?></a>
     <?php endif; ?>

--- a/admin/themes/default/items/search.php
+++ b/admin/themes/default/items/search.php
@@ -9,7 +9,11 @@ echo head(
 );
 echo $this->partial('items/search-form.php',
     [
-        'formAttributes' => ['id'=>'advanced-search-form'],
+        'formAttributes' => [
+            'id' => 'advanced-search-form', 
+            'role' => 'search',
+            'aria-label' => __('Search Items')
+        ],
         'useSidebar' => true
     ]
 );

--- a/admin/themes/default/items/search.php
+++ b/admin/themes/default/items/search.php
@@ -12,7 +12,7 @@ echo $this->partial('items/search-form.php',
         'formAttributes' => [
             'id' => 'advanced-search-form', 
             'role' => 'search',
-            'aria-label' => __('Search Items')
+            'aria-label' => __('Items')
         ],
         'useSidebar' => true
     ]

--- a/admin/themes/default/search/index.php
+++ b/admin/themes/default/search/index.php
@@ -5,7 +5,7 @@ $searchRecordTypes = get_search_record_types();
 ?>
 <?php echo search_filters(); ?>
 <?php if ($total_results): ?>
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Top pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 <table id="search-results">
     <thead>
         <tr>
@@ -33,7 +33,7 @@ $searchRecordTypes = get_search_record_types();
         <?php endforeach; ?>
     </tbody>
 </table>
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Bottom pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 <?php else: ?>
 <div id="no-results">
     <p><?php echo __('Your query returned no results.');?></p>

--- a/admin/themes/default/users/browse.php
+++ b/admin/themes/default/users/browse.php
@@ -42,7 +42,7 @@ echo flash();
     <button id="search-users-button"><?php echo __('Search users'); ?></button>
 </form>
 
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Top pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 <div class="table-responsive">
     <table id="users">
         <thead>

--- a/application/views/helpers/SearchForm.php
+++ b/application/views/helpers/SearchForm.php
@@ -68,6 +68,9 @@ class Omeka_View_Helper_SearchForm extends Zend_View_Helper_Abstract
         if (!isset($options['form_attributes']['id'])) {
             $options['form_attributes']['id'] = 'search-form';
         }
+        if (!isset($options['form_attributes']['aria-label'])) {
+            $options['form_attributes']['aria-label'] = option('site_title');
+        }
         $options['form_attributes']['method'] = 'get';
 
         $formParams = [

--- a/application/views/helpers/SearchForm.php
+++ b/application/views/helpers/SearchForm.php
@@ -68,9 +68,6 @@ class Omeka_View_Helper_SearchForm extends Zend_View_Helper_Abstract
         if (!isset($options['form_attributes']['id'])) {
             $options['form_attributes']['id'] = 'search-form';
         }
-        if (!isset($options['form_attributes']['aria-label'])) {
-            $options['form_attributes']['aria-label'] = __('Search');
-        }
         $options['form_attributes']['method'] = 'get';
 
         $formParams = [

--- a/application/views/scripts/collections/browse.php
+++ b/application/views/scripts/collections/browse.php
@@ -4,7 +4,7 @@ echo head(['title' => $pageTitle, 'bodyclass' => 'collections browse']);
 ?>
 
 <h1><?php echo $pageTitle; ?> <?php echo __('(%s total)', $total_results); ?></h1>
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Top pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 
 <?php
 $sortLinks[__('Title')] = 'Dublin Core,Title';
@@ -46,7 +46,7 @@ $sortLinks[__('Date Added')] = 'added';
 
 <?php endforeach; ?>
 
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Bottom pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 
 <?php fire_plugin_hook('public_collections_browse', ['collections' => $collections, 'view' => $this]); ?>
 

--- a/application/views/scripts/common/footer.php
+++ b/application/views/scripts/common/footer.php
@@ -2,7 +2,7 @@
 
         <footer role="contentinfo">
 
-            <nav id="bottom-nav">
+            <nav id="bottom-nav" aria-label="<?php echo __('Footer'); ?>">
                 <?php echo public_nav_main(); ?>
             </nav>
 

--- a/application/views/scripts/common/header.php
+++ b/application/views/scripts/common/header.php
@@ -51,7 +51,7 @@
 
             <div id="site-title"><?php echo link_to_home_page(theme_logo()); ?></div>
             
-            <nav id="top-nav" role="navigation">
+            <nav id="top-nav" aria-label="<?php __('Main menu'); ?>">
                 <?php echo public_nav_main(); ?>
             </nav>
 

--- a/application/views/scripts/items/browse.php
+++ b/application/views/scripts/items/browse.php
@@ -11,7 +11,7 @@ echo head(['title' => $pageTitle, 'bodyclass' => 'items browse']);
 
 <?php echo item_search_filters(); ?>
 
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Top pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 
 <?php if ($total_results > 0): ?>
 
@@ -54,7 +54,7 @@ $sortLinks[__('Date Added')] = 'added';
 </div><!-- end class="item hentry" -->
 <?php endforeach; ?>
 
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Bottom pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 
 <div id="outputs">
     <span class="outputs-label"><?php echo __('Output Formats'); ?></span>

--- a/application/views/scripts/items/browse.php
+++ b/application/views/scripts/items/browse.php
@@ -5,7 +5,7 @@ echo head(['title' => $pageTitle, 'bodyclass' => 'items browse']);
 
 <h1><?php echo $pageTitle;?> <?php echo __('(%s total)', $total_results); ?></h1>
 
-<nav class="items-nav navigation secondary-nav">
+<nav class="items-nav navigation secondary-nav" aria-label="<?php echo __('Items'); ?>">
     <?php echo public_nav_items(); ?>
 </nav>
 

--- a/application/views/scripts/items/search.php
+++ b/application/views/scripts/items/search.php
@@ -10,8 +10,12 @@ echo head(['title' => $pageTitle,
     <?php echo public_nav_items(); ?>
 </nav>
 
-<?php echo $this->partial('items/search-form.php',
-    ['formAttributes' =>
-        ['id' => 'advanced-search-form']]); ?>
+<?php echo $this->partial('items/search-form.php', [
+    'formAttributes' => [
+        'id' => 'advanced-search-form', 
+        'role' => 'search',
+        'aria-label' => __('Search Items')
+    ]
+]); ?>
 
 <?php echo foot(); ?>

--- a/application/views/scripts/items/search.php
+++ b/application/views/scripts/items/search.php
@@ -14,7 +14,7 @@ echo head(['title' => $pageTitle,
     'formAttributes' => [
         'id' => 'advanced-search-form', 
         'role' => 'search',
-        'aria-label' => __('Search Items')
+        'aria-label' => __('Items')
     ]
 ]); ?>
 

--- a/application/views/scripts/items/search.php
+++ b/application/views/scripts/items/search.php
@@ -6,7 +6,7 @@ echo head(['title' => $pageTitle,
 
 <h1><?php echo $pageTitle; ?></h1>
 
-<nav class="items-nav navigation secondary-nav">
+<nav class="items-nav navigation secondary-nav" aria-label="<?php echo __('Items'); ?>">
     <?php echo public_nav_items(); ?>
 </nav>
 

--- a/application/views/scripts/items/tags.php
+++ b/application/views/scripts/items/tags.php
@@ -5,7 +5,7 @@ echo head(['title' => $pageTitle, 'bodyclass' => 'items tags']);
 
 <h1><?php echo $pageTitle; ?></h1>
 
-<nav class="navigation items-nav secondary-nav">
+<nav class="navigation items-nav secondary-nav" aria-label="<?php echo __('Items'); ?>">
     <?php echo public_nav_items(); ?>
 </nav>
 

--- a/application/views/scripts/search/index.php
+++ b/application/views/scripts/search/index.php
@@ -6,7 +6,7 @@ $searchRecordTypes = get_search_record_types();
 <h1><?php echo $pageTitle; ?></h1>
 <?php echo search_filters(); ?>
 <?php if ($total_results): ?>
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Top pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 <table id="search-results">
     <thead>
         <tr>
@@ -34,7 +34,7 @@ $searchRecordTypes = get_search_record_types();
         <?php endforeach; ?>
     </tbody>
 </table>
-<?php echo pagination_links(['attributes' => ['aria-label' => __('Bottom pagination')]]); ?>
+<?php echo pagination_links(['attributes' => ['aria-label' => __('Pagination')]]); ?>
 <?php else: ?>
 <div id="no-results">
     <p><?php echo __('Your query returned no results.');?></p>


### PR DESCRIPTION
Affected landmarks include

* Appearance nav
* Content nav
* Admin nav
* Top search form
* Items only search form
* Items nav (across browse, tags, and advanced item search)
* Header (no longer has extraneous "banner" role)