### PR TITLE
Add option to include file texts in item search text

### DIFF
--- a/admin/themes/default/settings/edit-search.php
+++ b/admin/themes/default/settings/edit-search.php
@@ -31,6 +31,17 @@ echo flash();
         </div>
         <div class="field">
             <div class="two columns alpha">
+                <label for="search_include_file_texts"><?php echo __('Include Files with Items'); ?></label>
+            </div>
+            <div class="inputs five columns omega">
+                <p class="explanation"><?php echo __('Check this to include the text '
+                . 'of an item\'s files with the item itself, so a search matching a '
+                . 'file will also find the item.'); ?></p>
+                <?php echo $this->formCheckbox('search_include_file_texts', null, ['checked' => $this->searchIncludeFileTexts]); ?>
+            </div>
+        </div>
+        <div class="field">
+            <div class="two columns alpha">
                 <label><?php echo __('Index Records'); ?></label>
             </div>
             <div class="inputs five columns omega">

--- a/application/controllers/SettingsController.php
+++ b/application/controllers/SettingsController.php
@@ -99,6 +99,7 @@ class SettingsController extends Omeka_Controller_AbstractActionController
         $this->view->defaultQueryType = get_option('search_query_type') ?: 'keyword';
         $this->view->searchRecordTypes = get_search_record_types();
         $this->view->customSearchRecordTypes = get_custom_search_record_types();
+        $this->view->searchIncludeFileTexts = (bool) get_option('search_include_file_texts');
         $this->view->csrf = $csrf;
 
         if ($this->getRequest()->isPost()) {
@@ -120,6 +121,7 @@ class SettingsController extends Omeka_Controller_AbstractActionController
                     $option = serialize([]);
                 }
                 set_option('search_record_types', $option);
+                set_option('search_include_file_texts', !empty($_POST['search_include_file_texts']) ? '1' : '0');
                 $this->_helper->flashMessenger(__('You have changed which records are searchable in Omeka. Please re-index the records using the form below.'), 'success');
             }
 

--- a/application/models/File.php
+++ b/application/models/File.php
@@ -193,6 +193,7 @@ class File extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
         $this->_mixins[] = new Mixin_ElementText($this);
         $this->_mixins[] = new Mixin_Timestamp($this);
         $this->_mixins[] = new Mixin_Search($this);
+        $this->_mixins[] = new Mixin_ParentItemSearchText($this);
     }
 
     /**

--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -95,6 +95,7 @@ class Item extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Inte
         $this->_mixins[] = new Mixin_ElementText($this);
         $this->_mixins[] = new Mixin_PublicFeatured($this);
         $this->_mixins[] = new Mixin_Timestamp($this);
+        $this->_mixins[] = new Mixin_FileSearchTexts($this);
         $this->_mixins[] = new Mixin_Search($this);
     }
 

--- a/application/models/Mixin/ElementText.php
+++ b/application/models/Mixin/ElementText.php
@@ -96,10 +96,20 @@ class Mixin_ElementText extends Omeka_Record_Mixin_AbstractMixin
         if ($titles) {
             $this->_record->setSearchTextTitle($titles[0]->text);
         }
-        $elementTexts = apply_filters('search_element_texts', $this->getAllElementTexts());
-        foreach ($elementTexts as $elementText) {
+        foreach ($this->getSearchElementTexts() as $elementText) {
             $this->_record->addSearchText($elementText->text);
         }
+    }
+
+    /**
+     * Get this record's element texts that should be searchable, i.e. with
+     * the search_element_texts filter applied.
+     *
+     * @return array Set of ElementText records.
+     */
+    public function getSearchElementTexts()
+    {
+        return apply_filters('search_element_texts', $this->getAllElementTexts());
     }
 
     /**

--- a/application/models/Mixin/FileSearchTexts.php
+++ b/application/models/Mixin/FileSearchTexts.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Omeka
+ *
+ * @copyright Copyright 2007-2012 Roy Rosenzweig Center for History and New Media
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GNU GPLv3
+ */
+
+/**
+ * Include the search texts of an item's files in the item's search text.
+ *
+ * When file texts are configured to be included in item search texts, this
+ * mixin adds the texts of the item's files to the item's search text so a
+ * search matching a file will find the item.
+ *
+ * This mixin must be pushed before Mixin_Search so the file texts are
+ * included when the search text is saved.
+ *
+ * @package Omeka\Record\Mixin
+ */
+class Mixin_FileSearchTexts extends Omeka_Record_Mixin_AbstractMixin
+{
+    public function afterSave($args)
+    {
+        foreach ($this->_getFileSearchTexts() as $fileText) {
+            $this->_record->addSearchText($fileText);
+        }
+    }
+
+    /**
+     * Rebuild and save the item's search text directly, outside a save.
+     *
+     * Keeps the item's search text current when an attached file changes,
+     * without the side effects of a full item save (modified timestamp,
+     * plugin hooks). Must mirror what accumulates during a save: the Dublin
+     * Core title and element texts (Mixin_ElementText) and tag names
+     * (Mixin_Tag). File texts are shared with afterSave() via
+     * _getFileSearchTexts().
+     *
+     * @see Mixin_ParentItemSearchText
+     */
+    public function rebuildSearchText()
+    {
+        $item = $this->_record;
+
+        $title = null;
+        $text = '';
+
+        $titles = $item->getElementTexts('Dublin Core', 'Title');
+        if ($titles) {
+            $title = $titles[0]->text;
+        }
+        foreach ($item->getSearchElementTexts() as $elementText) {
+            $text .= "{$elementText->text} ";
+        }
+        foreach ($item->getTags() as $tag) {
+            $text .= "{$tag->name} ";
+        }
+        foreach ($this->_getFileSearchTexts() as $fileText) {
+            $text .= "$fileText ";
+        }
+
+        Mixin_Search::saveSearchText('Item', $item->id, $text, $title, $item->public);
+    }
+
+    /**
+     * Get the search texts of the item's files, if file texts are configured
+     * to be included in the item's search text.
+     *
+     * @return array Text strings.
+     */
+    private function _getFileSearchTexts()
+    {
+        if (!get_option('search_include_file_texts')) {
+            return [];
+        }
+
+        $texts = [];
+        foreach ($this->_record->getFiles() as $file) {
+            foreach ($file->getSearchElementTexts() as $elementText) {
+                $texts[] = $elementText->text;
+            }
+            release_object($file);
+        }
+        return $texts;
+    }
+}

--- a/application/models/Mixin/ParentItemSearchText.php
+++ b/application/models/Mixin/ParentItemSearchText.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Omeka
+ *
+ * @copyright Copyright 2007-2012 Roy Rosenzweig Center for History and New Media
+ * @license http://www.gnu.org/licenses/gpl-3.0.txt GNU GPLv3
+ */
+
+/**
+ * Keep the parent item's search text in sync with its file.
+ *
+ * When file texts are configured to be included in item search texts, a file
+ * that is saved or deleted rebuilds its item's search text so a search
+ * matching the file's texts will find the item.
+ *
+ * This mixin must be pushed after Mixin_ElementText so the file's element
+ * texts are already persisted when the item's search text is rebuilt. The
+ * rebuild itself is provided by Mixin_FileSearchTexts, mixed into Item.
+ *
+ * @see Mixin_FileSearchTexts
+ * @package Omeka\Record\Mixin
+ */
+class Mixin_ParentItemSearchText extends Omeka_Record_Mixin_AbstractMixin
+{
+    public function afterSave($args)
+    {
+        $this->_rebuildItemSearchText();
+    }
+
+    public function afterDelete()
+    {
+        $this->_rebuildItemSearchText();
+    }
+
+    /**
+     * Rebuild the parent item's search text.
+     */
+    private function _rebuildItemSearchText()
+    {
+        if (get_option('search_include_file_texts')
+            && ($item = $this->_record->getItem())
+        ) {
+            $item->rebuildSearchText();
+        }
+    }
+}


### PR DESCRIPTION
Adds a search setting, "Include Files with Items". When enabled, an item's search text includes its files' element texts, so a search matching a file also brings up the parent item: letting sites turn File results off without losing those matches. Re-indexing applies the setting to existing records.

Implemented as two mixins:

- `Mixin_FileSearchTexts` (Item) adds file texts to the item's search text on save and provides `rebuildSearchText()`;
- `Mixin_ParentItemSearchText` (File) rebuilds the parent item's search text when a file is saved or deleted, so file edits stay searchable without a reindex.

Fixes #1106 