### PR TITLE
Make tags example image accessible to screen readers

### DIFF
--- a/admin/themes/default/css/sass/pages/_tags.scss
+++ b/admin/themes/default/css/sass/pages/_tags.scss
@@ -2,19 +2,14 @@
     overflow: hidden;
 }
 
+.tag-desc {
+    max-width: 100%;
+    height: 4 * $spacing-l;
+}
+
 .tags h3 { margin: 0; }
 
 .tags ol { padding: 0 0 0 $spacing-m;  li { margin-left: $spacing-s; padding-left: $spacing-l; }}
-
-.tags ol:before {
-    content: "";
-    display: inline-block;
-    width: 180px;
-    height: 75px;
-    background:url('../images/tag-desc.png') no-repeat;
-    background-size: cover;
-    margin: $spacing-s 0 $spacing-l -$spacing-l;
-}
 
 .editable-inline div {
     display: inline-block;

--- a/admin/themes/default/css/style.css
+++ b/admin/themes/default/css/style.css
@@ -3312,6 +3312,11 @@ ul.details li:last-child {
   overflow: hidden;
 }
 
+.tag-desc {
+  max-width: 100%;
+  height: 80px;
+}
+
 .tags h3 {
   margin: 0;
 }
@@ -3322,16 +3327,6 @@ ul.details li:last-child {
 .tags ol li {
   margin-left: 5px;
   padding-left: 20px;
-}
-
-.tags ol:before {
-  content: "";
-  display: inline-block;
-  width: 180px;
-  height: 75px;
-  background: url("../images/tag-desc.png") no-repeat;
-  background-size: cover;
-  margin: 5px 0 0px;
 }
 
 .editable-inline div {

--- a/admin/themes/default/tags/browse.php
+++ b/admin/themes/default/tags/browse.php
@@ -18,6 +18,8 @@ echo flash();
 <section class="three columns alpha">
     <h2><?php echo __('Editing Tags'); ?></h2>
 
+    <img class="tag-desc" src="<?php echo img('tag-desc.png'); ?>" alt="<?php echo __('Example of editable tag, labeled "1" for the associated record count, "2" for editable name, and "3" for delete action.'); ?>">
+
     <ol>
         <li><?php echo __('This number counts all records associated with a tag. Filtering "Record types" to "Items" will provide links to all items containing the tag.'); ?></li>
         <li><?php echo __('To edit the tag name, click the name and begin editing, and hit "enter" to save. To cancel an edit, click the ESC key or click away from the tag.'); ?></li>

--- a/admin/themes/default/tags/browse.php
+++ b/admin/themes/default/tags/browse.php
@@ -18,7 +18,7 @@ echo flash();
 <section class="three columns alpha">
     <h2><?php echo __('Editing Tags'); ?></h2>
 
-    <img class="tag-desc" src="<?php echo img('tag-desc.png'); ?>" alt="<?php echo __('Example of editable tag, labeled "1" for the associated record count, "2" for editable name, and "3" for delete action.'); ?>">
+    <img class="tag-desc" src="<?php echo img('tag-desc.png'); ?>" alt='<?php echo __('Example of editable tag, labeled "1" for the associated record count, "2" for editable name, and "3" for delete action.'); ?>'>
 
     <ol>
         <li><?php echo __('This number counts all records associated with a tag. Filtering "Record types" to "Items" will provide links to all items containing the tag.'); ?></li>


### PR DESCRIPTION
This converts the tag example from a background image into an actual `<img>` element with descriptive alt text.